### PR TITLE
Fix several bugs with native GDB DAP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ This is an MCP (Model Context Protocol) server that bridges MCP clients with DAP
 4. **Error Propagation**: DAP response `Success` field is checked; error messages from `response.Message` are wrapped in Go errors
 5. **Capability-Gated Tools**: `set-variable`, `disassemble`, and `restart` are only registered when the DAP adapter reports support
 6. **Dynamic Tool Registration**: Only `debug` is registered initially; session tools replace it after a session starts, then are removed when the session stops
-7. **Single-Reader Architecture**: Only one goroutine reads from the DAP connection at a time — concurrent tool calls that both read DAP messages will race
+7. **Serialized DAP Access**: A mutex on `debuggerSession` serializes all tool calls, preventing concurrent reads from the single DAP connection
 
 ## Development Commands
 
@@ -195,7 +195,7 @@ func TestSomething(t *testing.T) {
 2. **Frame IDs vs Thread IDs**: Frame IDs come from stack traces, thread IDs from the threads request. Delve uses frame IDs starting at 1000.
 3. **Variables References**: The `variablesReference` in scopes/variables is a DAP protocol identifier, not a simple index. Delve uses frame_id+1 for locals scope (e.g., 1001 for frame 1000).
 4. **Stopped Event Format**: Contains `Reason` field ("breakpoint", "function breakpoint", "step", "entry", "pause", etc.) and `ThreadId`
-5. **Concurrent DAP Reads**: The DAP client has a single reader — concurrent tool calls that both read from the DAP connection will race. This limits features like concurrent continue + pause.
+5. **Serialized Tool Calls**: All tool calls are serialized by a mutex. Concurrent MCP tool calls will queue rather than race. Long-running operations (continue, step) hold the lock until completion.
 6. **Capability-Gated Tools**: `set-variable`, `disassemble`, and `restart` are only available when the DAP adapter reports support via capabilities
 7. **Test Binary Paths**: Must be absolute paths for the `debug` tool in binary mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,15 +25,15 @@ This is an MCP (Model Context Protocol) server that bridges MCP clients with DAP
 - All MCP tools are methods on `debuggerSession` struct
 - Each tool method signature: `func (ds *debuggerSession) toolName(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[ParamsType]) (*mcp.CallToolResultFor[any], error)`
 - Tools send DAP requests via `ds.client` and read/parse responses
-- `readAndValidateResponse()` is a common pattern for simple request/response flows
-- `readTypedResponse[T]()` for responses that need type-specific handling
+- `readAndValidateResponse(client, requestSeq, errorPrefix)` matches responses by `request_seq`, skipping unrelated responses
+- `readTypedResponse[T](client, requestSeq)` matches typed responses by `request_seq`, skipping unrelated responses
 - Tools that wait for stopped/terminated events loop on `ReadMessage()` until they receive the expected event
 
 **dap.go**: DAP client implementation
 - `DAPClient` manages TCP or stdio connection to DAP server
 - Wraps `github.com/google/go-dap` protocol messages
-- All DAP requests are synchronous: send request, read response
-- Maintains sequence numbers for protocol compliance
+- All DAP request methods return `(int, error)` where `int` is the request sequence number
+- Sequence numbers are used to match responses to requests via `request_seq` field
 
 **backend.go**: Debugger backend abstraction
 - `DebuggerBackend` interface abstracts debugger-specific behavior (spawning, launch args, transport)
@@ -57,7 +57,7 @@ This is an MCP (Model Context Protocol) server that bridges MCP clients with DAP
 ### Key Patterns
 
 1. **Tool Parameter Structs**: Each tool has a corresponding `*Params` struct with JSON/MCP tags
-2. **DAP Message Handling**: Response reading uses type switches on `dap.Message` interfaces
+2. **DAP Message Handling**: Response reading matches by `request_seq` (from the DAP protocol), skipping unrelated responses from other requests. go-dap decodes all failed responses as `*dap.ErrorResponse`, so matching by Go type alone is insufficient
 3. **Event vs Response**: Some operations (continue, step, etc.) wait for `StoppedEvent` or `TerminatedEvent` rather than just response messages
 4. **Error Propagation**: DAP response `Success` field is checked; error messages from `response.Message` are wrapped in Go errors
 5. **Capability-Gated Tools**: `set-variable`, `disassemble`, and `restart` are only registered when the DAP adapter reports support
@@ -198,6 +198,9 @@ func TestSomething(t *testing.T) {
 5. **Serialized Tool Calls**: All tool calls are serialized by a mutex. Concurrent MCP tool calls will queue rather than race. Long-running operations (continue, step) hold the lock until completion.
 6. **Capability-Gated Tools**: `set-variable`, `disassemble`, and `restart` are only available when the DAP adapter reports support via capabilities
 7. **Test Binary Paths**: Must be absolute paths for the `debug` tool in binary mode
+8. **go-dap ErrorResponse Decoding**: go-dap decodes ALL failed responses (`success: false`) as `*dap.ErrorResponse` regardless of command. Response matching must use `request_seq`, not Go type
+9. **DAP Response Ordering**: GDB native DAP may send responses out of order (e.g., `StoppedEvent` before `ContinueResponse`). Out-of-order responses are skipped by `request_seq` matching
+10. **go-dap `omitempty` on FrameId**: `EvaluateArguments.FrameId` has `omitempty`, so `frameId=0` is silently dropped. `EvaluateRequest` uses raw JSON map to work around this
 
 ## Dependencies
 

--- a/backend.go
+++ b/backend.go
@@ -203,9 +203,12 @@ func (g *gdbBackend) LaunchArgs(mode, programPath string, stopOnEntry bool, prog
 
 	cwd, _ := os.Getwd()
 	args := map[string]any{
-		"program":     programPath,
-		"cwd":         cwd,
-		"stopAtEntry": stopOnEntry,
+		"program": programPath,
+		"cwd":     cwd,
+		// GDB's native DAP distinguishes stopOnEntry (starti, first instruction)
+		// from stopAtBeginningOfMainSubprogram (start, main function).
+		// We use the latter since stopping at main is almost always the intent.
+		"stopAtBeginningOfMainSubprogram": stopOnEntry,
 	}
 	if len(programArgs) > 0 {
 		args["args"] = programArgs

--- a/backend_test.go
+++ b/backend_test.go
@@ -126,8 +126,8 @@ func TestGDBBackendLaunchArgs(t *testing.T) {
 	if args["program"] != "/path/to/prog" {
 		t.Errorf("expected program=/path/to/prog, got: %v", args["program"])
 	}
-	if args["stopAtEntry"] != false {
-		t.Errorf("expected stopAtEntry=false, got: %v", args["stopAtEntry"])
+	if args["stopAtBeginningOfMainSubprogram"] != false {
+		t.Errorf("expected stopAtBeginningOfMainSubprogram=false, got: %v", args["stopAtBeginningOfMainSubprogram"])
 	}
 	if _, ok := args["cwd"]; !ok {
 		t.Error("expected cwd to be set")

--- a/dap.go
+++ b/dap.go
@@ -55,7 +55,7 @@ func (c *DAPClient) Close() {
 
 // InitializeRequest sends an 'initialize' request and returns the server's capabilities.
 func (c *DAPClient) InitializeRequest(adapterID string) (dap.Capabilities, error) {
-	req, _ := c.newRequest("initialize")
+	req := c.newRequest("initialize")
 	request := &dap.InitializeRequest{Request: *req}
 	request.Arguments = dap.InitializeRequestArguments{
 		AdapterID:                    adapterID,
@@ -96,7 +96,7 @@ func (c *DAPClient) ReadMessage() (dap.Message, error) {
 
 // LaunchRequest sends a 'launch' request with the specified args.
 func (c *DAPClient) LaunchRequest(mode, program string, stopOnEntry bool, args []string) (int, error) {
-	req, seq := c.newRequest("launch")
+	req := c.newRequest("launch")
 	request := &dap.LaunchRequest{Request: *req}
 	launchArgs := map[string]any{
 		"request":     "launch",
@@ -108,12 +108,12 @@ func (c *DAPClient) LaunchRequest(mode, program string, stopOnEntry bool, args [
 		launchArgs["args"] = args
 	}
 	request.Arguments = toRawMessage(launchArgs)
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // CoreRequest sends a 'launch' request in core dump mode.
 func (c *DAPClient) CoreRequest(program, coreFilePath string) (int, error) {
-	req, seq := c.newRequest("launch")
+	req := c.newRequest("launch")
 	request := &dap.LaunchRequest{Request: *req}
 	request.Arguments = toRawMessage(map[string]any{
 		"request":      "launch",
@@ -121,20 +121,19 @@ func (c *DAPClient) CoreRequest(program, coreFilePath string) (int, error) {
 		"program":      program,
 		"coreFilePath": coreFilePath,
 	})
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // newRequest creates a new DAP request with the given command and an
-// auto-incremented sequence number. Returns both the request and the
-// sequence number explicitly (rather than relying on promoted field access).
-func (c *DAPClient) newRequest(command string) (*dap.Request, int) {
+// auto-incremented sequence number. The caller can read the assigned
+// sequence number from the returned request's Seq field.
+func (c *DAPClient) newRequest(command string) *dap.Request {
 	request := &dap.Request{}
 	request.Type = "request"
 	request.Command = command
 	request.Seq = c.seq
-	seq := c.seq
 	c.seq++
-	return request, seq
+	return request
 }
 
 func (c *DAPClient) send(request dap.Message) error {
@@ -148,7 +147,7 @@ func toRawMessage(in any) json.RawMessage {
 
 // SetBreakpointsRequest sends a 'setBreakpoints' request.
 func (c *DAPClient) SetBreakpointsRequest(file string, lines []int) (int, error) {
-	req, seq := c.newRequest("setBreakpoints")
+	req := c.newRequest("setBreakpoints")
 	request := &dap.SetBreakpointsRequest{Request: *req}
 	request.Arguments = dap.SetBreakpointsArguments{
 		Source: dap.Source{
@@ -160,12 +159,12 @@ func (c *DAPClient) SetBreakpointsRequest(file string, lines []int) (int, error)
 	for i, l := range lines {
 		request.Arguments.Breakpoints[i].Line = l
 	}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // SetFunctionBreakpointsRequest sends a 'setFunctionBreakpoints' request.
 func (c *DAPClient) SetFunctionBreakpointsRequest(functions []string) (int, error) {
-	req, seq := c.newRequest("setFunctionBreakpoints")
+	req := c.newRequest("setFunctionBreakpoints")
 	request := &dap.SetFunctionBreakpointsRequest{Request: *req}
 	request.Arguments = dap.SetFunctionBreakpointsArguments{
 		Breakpoints: make([]dap.FunctionBreakpoint, len(functions)),
@@ -173,87 +172,87 @@ func (c *DAPClient) SetFunctionBreakpointsRequest(functions []string) (int, erro
 	for i, f := range functions {
 		request.Arguments.Breakpoints[i].Name = f
 	}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ConfigurationDoneRequest sends a 'configurationDone' request.
 func (c *DAPClient) ConfigurationDoneRequest() (int, error) {
-	req, seq := c.newRequest("configurationDone")
+	req := c.newRequest("configurationDone")
 	request := &dap.ConfigurationDoneRequest{Request: *req}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ContinueRequest sends a 'continue' request.
 func (c *DAPClient) ContinueRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("continue")
+	req := c.newRequest("continue")
 	request := &dap.ContinueRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // NextRequest sends a 'next' request.
 func (c *DAPClient) NextRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("next")
+	req := c.newRequest("next")
 	request := &dap.NextRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // StepInRequest sends a 'stepIn' request.
 func (c *DAPClient) StepInRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("stepIn")
+	req := c.newRequest("stepIn")
 	request := &dap.StepInRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // StepOutRequest sends a 'stepOut' request.
 func (c *DAPClient) StepOutRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("stepOut")
+	req := c.newRequest("stepOut")
 	request := &dap.StepOutRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // PauseRequest sends a 'pause' request.
 func (c *DAPClient) PauseRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("pause")
+	req := c.newRequest("pause")
 	request := &dap.PauseRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ThreadsRequest sends a 'threads' request.
 func (c *DAPClient) ThreadsRequest() (int, error) {
-	req, seq := c.newRequest("threads")
+	req := c.newRequest("threads")
 	request := &dap.ThreadsRequest{Request: *req}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // StackTraceRequest sends a 'stackTrace' request.
 func (c *DAPClient) StackTraceRequest(threadID, startFrame, levels int) (int, error) {
-	req, seq := c.newRequest("stackTrace")
+	req := c.newRequest("stackTrace")
 	request := &dap.StackTraceRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
 	request.Arguments.StartFrame = startFrame
 	request.Arguments.Levels = levels
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ScopesRequest sends a 'scopes' request.
 func (c *DAPClient) ScopesRequest(frameID int) (int, error) {
-	req, seq := c.newRequest("scopes")
+	req := c.newRequest("scopes")
 	request := &dap.ScopesRequest{Request: *req}
 	request.Arguments.FrameId = frameID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // VariablesRequest sends a 'variables' request.
 func (c *DAPClient) VariablesRequest(variablesReference int) (int, error) {
-	req, seq := c.newRequest("variables")
+	req := c.newRequest("variables")
 	request := &dap.VariablesRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesReference
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // EvaluateRequest sends an 'evaluate' request.
@@ -262,7 +261,7 @@ func (c *DAPClient) VariablesRequest(variablesReference int) (int, error) {
 // wire. GDB's native DAP uses 0-based frame IDs, so omitting frameId=0
 // causes evaluation in global scope where local variables aren't visible.
 func (c *DAPClient) EvaluateRequest(expression string, frameID int, context string) (int, error) {
-	req, seq := c.newRequest("evaluate")
+	req := c.newRequest("evaluate")
 	args := map[string]any{
 		"expression": expression,
 		"frameId":    frameID,
@@ -274,148 +273,148 @@ func (c *DAPClient) EvaluateRequest(expression string, frameID int, context stri
 		dap.Request
 		Arguments map[string]any `json:"arguments"`
 	}{Request: *req, Arguments: args}
-	return seq, dap.WriteProtocolMessage(c.rwc, &msg)
+	return req.Seq, dap.WriteProtocolMessage(c.rwc, &msg)
 }
 
 // DisconnectRequest sends a 'disconnect' request.
 func (c *DAPClient) DisconnectRequest(terminateDebuggee bool) (int, error) {
-	req, seq := c.newRequest("disconnect")
+	req := c.newRequest("disconnect")
 	request := &dap.DisconnectRequest{Request: *req}
 	request.Arguments = &dap.DisconnectArguments{
 		TerminateDebuggee: terminateDebuggee,
 	}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ExceptionInfoRequest sends an 'exceptionInfo' request.
 func (c *DAPClient) ExceptionInfoRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("exceptionInfo")
+	req := c.newRequest("exceptionInfo")
 	request := &dap.ExceptionInfoRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // SetVariableRequest sends a 'setVariable' request.
 func (c *DAPClient) SetVariableRequest(variablesRef int, name, value string) (int, error) {
-	req, seq := c.newRequest("setVariable")
+	req := c.newRequest("setVariable")
 	request := &dap.SetVariableRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesRef
 	request.Arguments.Name = name
 	request.Arguments.Value = value
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // RestartRequest sends a 'restart' request with specified arguments, if provided.
 func (c *DAPClient) RestartRequest(arguments map[string]any) (int, error) {
-	req, seq := c.newRequest("restart")
+	req := c.newRequest("restart")
 	request := &dap.RestartRequest{Request: *req}
 	if arguments != nil {
 		request.Arguments = toRawMessage(arguments)
 	}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // TerminateRequest sends a 'terminate' request.
 func (c *DAPClient) TerminateRequest() (int, error) {
-	req, seq := c.newRequest("terminate")
+	req := c.newRequest("terminate")
 	request := &dap.TerminateRequest{Request: *req}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // StepBackRequest sends a 'stepBack' request.
 func (c *DAPClient) StepBackRequest(threadID int) (int, error) {
-	req, seq := c.newRequest("stepBack")
+	req := c.newRequest("stepBack")
 	request := &dap.StepBackRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // LoadedSourcesRequest sends a 'loadedSources' request.
 func (c *DAPClient) LoadedSourcesRequest() (int, error) {
-	req, seq := c.newRequest("loadedSources")
+	req := c.newRequest("loadedSources")
 	request := &dap.LoadedSourcesRequest{Request: *req}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // ModulesRequest sends a 'modules' request.
 func (c *DAPClient) ModulesRequest() (int, error) {
-	req, seq := c.newRequest("modules")
+	req := c.newRequest("modules")
 	request := &dap.ModulesRequest{Request: *req}
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // BreakpointLocationsRequest sends a 'breakpointLocations' request.
 func (c *DAPClient) BreakpointLocationsRequest(source string, line int) (int, error) {
-	req, seq := c.newRequest("breakpointLocations")
+	req := c.newRequest("breakpointLocations")
 	request := &dap.BreakpointLocationsRequest{Request: *req}
 	request.Arguments.Source = dap.Source{
 		Path: source,
 	}
 	request.Arguments.Line = line
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // CompletionsRequest sends a 'completions' request.
 func (c *DAPClient) CompletionsRequest(text string, column int, frameID int) (int, error) {
-	req, seq := c.newRequest("completions")
+	req := c.newRequest("completions")
 	request := &dap.CompletionsRequest{Request: *req}
 	request.Arguments.Text = text
 	request.Arguments.Column = column
 	request.Arguments.FrameId = frameID
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // DisassembleRequest sends a 'disassemble' request.
 func (c *DAPClient) DisassembleRequest(memoryReference string, instructionOffset, instructionCount int) (int, error) {
-	req, seq := c.newRequest("disassemble")
+	req := c.newRequest("disassemble")
 	request := &dap.DisassembleRequest{Request: *req}
 	request.Arguments.MemoryReference = memoryReference
 	request.Arguments.InstructionOffset = instructionOffset
 	request.Arguments.InstructionCount = instructionCount
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // SetExceptionBreakpointsRequest sends a 'setExceptionBreakpoints' request.
 func (c *DAPClient) SetExceptionBreakpointsRequest(filters []string) (int, error) {
-	req, seq := c.newRequest("setExceptionBreakpoints")
+	req := c.newRequest("setExceptionBreakpoints")
 	request := &dap.SetExceptionBreakpointsRequest{Request: *req}
 	request.Arguments.Filters = filters
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // DataBreakpointInfoRequest sends a 'dataBreakpointInfo' request.
 func (c *DAPClient) DataBreakpointInfoRequest(variablesRef int, name string) (int, error) {
-	req, seq := c.newRequest("dataBreakpointInfo")
+	req := c.newRequest("dataBreakpointInfo")
 	request := &dap.DataBreakpointInfoRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesRef
 	request.Arguments.Name = name
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // SetDataBreakpointsRequest sends a 'setDataBreakpoints' request.
 func (c *DAPClient) SetDataBreakpointsRequest(breakpoints []dap.DataBreakpoint) (int, error) {
-	req, seq := c.newRequest("setDataBreakpoints")
+	req := c.newRequest("setDataBreakpoints")
 	request := &dap.SetDataBreakpointsRequest{Request: *req}
 	request.Arguments.Breakpoints = breakpoints
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // SourceRequest sends a 'source' request.
 func (c *DAPClient) SourceRequest(sourceRef int) (int, error) {
-	req, seq := c.newRequest("source")
+	req := c.newRequest("source")
 	request := &dap.SourceRequest{Request: *req}
 	request.Arguments.SourceReference = sourceRef
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }
 
 // AttachRequest sends an 'attach' request.
 func (c *DAPClient) AttachRequest(mode string, processID int) (int, error) {
-	req, seq := c.newRequest("attach")
+	req := c.newRequest("attach")
 	request := &dap.AttachRequest{Request: *req}
 	request.Arguments = toRawMessage(map[string]any{
 		"request":   "attach",
 		"mode":      mode,
 		"processId": processID,
 	})
-	return seq, c.send(request)
+	return req.Seq, c.send(request)
 }

--- a/dap.go
+++ b/dap.go
@@ -18,7 +18,9 @@ type readWriteCloser struct {
 
 // DAPClient is a synchronous Debug Adapter Protocol client.
 // It manages a connection to a DAP server and provides methods for
-// sending each DAP request type.
+// sending each DAP request type. Each request method returns the
+// sequence number of the sent request, which callers use to match
+// the corresponding response via request_seq.
 type DAPClient struct {
 	rwc    io.ReadWriteCloser
 	reader *bufio.Reader
@@ -53,7 +55,8 @@ func (c *DAPClient) Close() {
 
 // InitializeRequest sends an 'initialize' request and returns the server's capabilities.
 func (c *DAPClient) InitializeRequest(adapterID string) (dap.Capabilities, error) {
-	request := &dap.InitializeRequest{Request: *c.newRequest("initialize")}
+	req, _ := c.newRequest("initialize")
+	request := &dap.InitializeRequest{Request: *req}
 	request.Arguments = dap.InitializeRequestArguments{
 		AdapterID:                    adapterID,
 		PathFormat:                   "path",
@@ -92,8 +95,9 @@ func (c *DAPClient) ReadMessage() (dap.Message, error) {
 }
 
 // LaunchRequest sends a 'launch' request with the specified args.
-func (c *DAPClient) LaunchRequest(mode, program string, stopOnEntry bool, args []string) error {
-	request := &dap.LaunchRequest{Request: *c.newRequest("launch")}
+func (c *DAPClient) LaunchRequest(mode, program string, stopOnEntry bool, args []string) (int, error) {
+	req, seq := c.newRequest("launch")
+	request := &dap.LaunchRequest{Request: *req}
 	launchArgs := map[string]any{
 		"request":     "launch",
 		"mode":        mode,
@@ -104,28 +108,33 @@ func (c *DAPClient) LaunchRequest(mode, program string, stopOnEntry bool, args [
 		launchArgs["args"] = args
 	}
 	request.Arguments = toRawMessage(launchArgs)
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // CoreRequest sends a 'launch' request in core dump mode.
-func (c *DAPClient) CoreRequest(program, coreFilePath string) error {
-	request := &dap.LaunchRequest{Request: *c.newRequest("launch")}
+func (c *DAPClient) CoreRequest(program, coreFilePath string) (int, error) {
+	req, seq := c.newRequest("launch")
+	request := &dap.LaunchRequest{Request: *req}
 	request.Arguments = toRawMessage(map[string]any{
 		"request":      "launch",
 		"mode":         "core",
 		"program":      program,
 		"coreFilePath": coreFilePath,
 	})
-	return c.send(request)
+	return seq, c.send(request)
 }
 
-func (c *DAPClient) newRequest(command string) *dap.Request {
+// newRequest creates a new DAP request with the given command and an
+// auto-incremented sequence number. Returns both the request and the
+// sequence number explicitly (rather than relying on promoted field access).
+func (c *DAPClient) newRequest(command string) (*dap.Request, int) {
 	request := &dap.Request{}
 	request.Type = "request"
 	request.Command = command
 	request.Seq = c.seq
+	seq := c.seq
 	c.seq++
-	return request
+	return request, seq
 }
 
 func (c *DAPClient) send(request dap.Message) error {
@@ -138,8 +147,9 @@ func toRawMessage(in any) json.RawMessage {
 }
 
 // SetBreakpointsRequest sends a 'setBreakpoints' request.
-func (c *DAPClient) SetBreakpointsRequest(file string, lines []int) error {
-	request := &dap.SetBreakpointsRequest{Request: *c.newRequest("setBreakpoints")}
+func (c *DAPClient) SetBreakpointsRequest(file string, lines []int) (int, error) {
+	req, seq := c.newRequest("setBreakpoints")
+	request := &dap.SetBreakpointsRequest{Request: *req}
 	request.Arguments = dap.SetBreakpointsArguments{
 		Source: dap.Source{
 			Name: file,
@@ -150,89 +160,100 @@ func (c *DAPClient) SetBreakpointsRequest(file string, lines []int) error {
 	for i, l := range lines {
 		request.Arguments.Breakpoints[i].Line = l
 	}
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // SetFunctionBreakpointsRequest sends a 'setFunctionBreakpoints' request.
-func (c *DAPClient) SetFunctionBreakpointsRequest(functions []string) error {
-	request := &dap.SetFunctionBreakpointsRequest{Request: *c.newRequest("setFunctionBreakpoints")}
+func (c *DAPClient) SetFunctionBreakpointsRequest(functions []string) (int, error) {
+	req, seq := c.newRequest("setFunctionBreakpoints")
+	request := &dap.SetFunctionBreakpointsRequest{Request: *req}
 	request.Arguments = dap.SetFunctionBreakpointsArguments{
 		Breakpoints: make([]dap.FunctionBreakpoint, len(functions)),
 	}
 	for i, f := range functions {
 		request.Arguments.Breakpoints[i].Name = f
 	}
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // ConfigurationDoneRequest sends a 'configurationDone' request.
-func (c *DAPClient) ConfigurationDoneRequest() error {
-	request := &dap.ConfigurationDoneRequest{Request: *c.newRequest("configurationDone")}
-	return c.send(request)
+func (c *DAPClient) ConfigurationDoneRequest() (int, error) {
+	req, seq := c.newRequest("configurationDone")
+	request := &dap.ConfigurationDoneRequest{Request: *req}
+	return seq, c.send(request)
 }
 
 // ContinueRequest sends a 'continue' request.
-func (c *DAPClient) ContinueRequest(threadID int) error {
-	request := &dap.ContinueRequest{Request: *c.newRequest("continue")}
+func (c *DAPClient) ContinueRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("continue")
+	request := &dap.ContinueRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // NextRequest sends a 'next' request.
-func (c *DAPClient) NextRequest(threadID int) error {
-	request := &dap.NextRequest{Request: *c.newRequest("next")}
+func (c *DAPClient) NextRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("next")
+	request := &dap.NextRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // StepInRequest sends a 'stepIn' request.
-func (c *DAPClient) StepInRequest(threadID int) error {
-	request := &dap.StepInRequest{Request: *c.newRequest("stepIn")}
+func (c *DAPClient) StepInRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("stepIn")
+	request := &dap.StepInRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // StepOutRequest sends a 'stepOut' request.
-func (c *DAPClient) StepOutRequest(threadID int) error {
-	request := &dap.StepOutRequest{Request: *c.newRequest("stepOut")}
+func (c *DAPClient) StepOutRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("stepOut")
+	request := &dap.StepOutRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // PauseRequest sends a 'pause' request.
-func (c *DAPClient) PauseRequest(threadID int) error {
-	request := &dap.PauseRequest{Request: *c.newRequest("pause")}
+func (c *DAPClient) PauseRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("pause")
+	request := &dap.PauseRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // ThreadsRequest sends a 'threads' request.
-func (c *DAPClient) ThreadsRequest() error {
-	request := &dap.ThreadsRequest{Request: *c.newRequest("threads")}
-	return c.send(request)
+func (c *DAPClient) ThreadsRequest() (int, error) {
+	req, seq := c.newRequest("threads")
+	request := &dap.ThreadsRequest{Request: *req}
+	return seq, c.send(request)
 }
 
 // StackTraceRequest sends a 'stackTrace' request.
-func (c *DAPClient) StackTraceRequest(threadID, startFrame, levels int) error {
-	request := &dap.StackTraceRequest{Request: *c.newRequest("stackTrace")}
+func (c *DAPClient) StackTraceRequest(threadID, startFrame, levels int) (int, error) {
+	req, seq := c.newRequest("stackTrace")
+	request := &dap.StackTraceRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
 	request.Arguments.StartFrame = startFrame
 	request.Arguments.Levels = levels
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // ScopesRequest sends a 'scopes' request.
-func (c *DAPClient) ScopesRequest(frameID int) error {
-	request := &dap.ScopesRequest{Request: *c.newRequest("scopes")}
+func (c *DAPClient) ScopesRequest(frameID int) (int, error) {
+	req, seq := c.newRequest("scopes")
+	request := &dap.ScopesRequest{Request: *req}
 	request.Arguments.FrameId = frameID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // VariablesRequest sends a 'variables' request.
-func (c *DAPClient) VariablesRequest(variablesReference int) error {
-	request := &dap.VariablesRequest{Request: *c.newRequest("variables")}
+func (c *DAPClient) VariablesRequest(variablesReference int) (int, error) {
+	req, seq := c.newRequest("variables")
+	request := &dap.VariablesRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesReference
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // EvaluateRequest sends an 'evaluate' request.
@@ -240,8 +261,8 @@ func (c *DAPClient) VariablesRequest(variablesReference int) error {
 // because go-dap uses omitempty on FrameId, which drops frameId=0 from the
 // wire. GDB's native DAP uses 0-based frame IDs, so omitting frameId=0
 // causes evaluation in global scope where local variables aren't visible.
-func (c *DAPClient) EvaluateRequest(expression string, frameID int, context string) error {
-	req := c.newRequest("evaluate")
+func (c *DAPClient) EvaluateRequest(expression string, frameID int, context string) (int, error) {
+	req, seq := c.newRequest("evaluate")
 	args := map[string]any{
 		"expression": expression,
 		"frameId":    frameID,
@@ -253,132 +274,148 @@ func (c *DAPClient) EvaluateRequest(expression string, frameID int, context stri
 		dap.Request
 		Arguments map[string]any `json:"arguments"`
 	}{Request: *req, Arguments: args}
-	return dap.WriteProtocolMessage(c.rwc, &msg)
+	return seq, dap.WriteProtocolMessage(c.rwc, &msg)
 }
 
 // DisconnectRequest sends a 'disconnect' request.
-func (c *DAPClient) DisconnectRequest(terminateDebuggee bool) error {
-	request := &dap.DisconnectRequest{Request: *c.newRequest("disconnect")}
+func (c *DAPClient) DisconnectRequest(terminateDebuggee bool) (int, error) {
+	req, seq := c.newRequest("disconnect")
+	request := &dap.DisconnectRequest{Request: *req}
 	request.Arguments = &dap.DisconnectArguments{
 		TerminateDebuggee: terminateDebuggee,
 	}
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // ExceptionInfoRequest sends an 'exceptionInfo' request.
-func (c *DAPClient) ExceptionInfoRequest(threadID int) error {
-	request := &dap.ExceptionInfoRequest{Request: *c.newRequest("exceptionInfo")}
+func (c *DAPClient) ExceptionInfoRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("exceptionInfo")
+	request := &dap.ExceptionInfoRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // SetVariableRequest sends a 'setVariable' request.
-func (c *DAPClient) SetVariableRequest(variablesRef int, name, value string) error {
-	request := &dap.SetVariableRequest{Request: *c.newRequest("setVariable")}
+func (c *DAPClient) SetVariableRequest(variablesRef int, name, value string) (int, error) {
+	req, seq := c.newRequest("setVariable")
+	request := &dap.SetVariableRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesRef
 	request.Arguments.Name = name
 	request.Arguments.Value = value
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // RestartRequest sends a 'restart' request with specified arguments, if provided.
-func (c *DAPClient) RestartRequest(arguments map[string]any) error {
-	request := &dap.RestartRequest{Request: *c.newRequest("restart")}
+func (c *DAPClient) RestartRequest(arguments map[string]any) (int, error) {
+	req, seq := c.newRequest("restart")
+	request := &dap.RestartRequest{Request: *req}
 	if arguments != nil {
 		request.Arguments = toRawMessage(arguments)
 	}
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // TerminateRequest sends a 'terminate' request.
-func (c *DAPClient) TerminateRequest() error {
-	request := &dap.TerminateRequest{Request: *c.newRequest("terminate")}
-	return c.send(request)
+func (c *DAPClient) TerminateRequest() (int, error) {
+	req, seq := c.newRequest("terminate")
+	request := &dap.TerminateRequest{Request: *req}
+	return seq, c.send(request)
 }
 
 // StepBackRequest sends a 'stepBack' request.
-func (c *DAPClient) StepBackRequest(threadID int) error {
-	request := &dap.StepBackRequest{Request: *c.newRequest("stepBack")}
+func (c *DAPClient) StepBackRequest(threadID int) (int, error) {
+	req, seq := c.newRequest("stepBack")
+	request := &dap.StepBackRequest{Request: *req}
 	request.Arguments.ThreadId = threadID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // LoadedSourcesRequest sends a 'loadedSources' request.
-func (c *DAPClient) LoadedSourcesRequest() error {
-	request := &dap.LoadedSourcesRequest{Request: *c.newRequest("loadedSources")}
-	return c.send(request)
+func (c *DAPClient) LoadedSourcesRequest() (int, error) {
+	req, seq := c.newRequest("loadedSources")
+	request := &dap.LoadedSourcesRequest{Request: *req}
+	return seq, c.send(request)
 }
 
 // ModulesRequest sends a 'modules' request.
-func (c *DAPClient) ModulesRequest() error {
-	request := &dap.ModulesRequest{Request: *c.newRequest("modules")}
-	return c.send(request)
+func (c *DAPClient) ModulesRequest() (int, error) {
+	req, seq := c.newRequest("modules")
+	request := &dap.ModulesRequest{Request: *req}
+	return seq, c.send(request)
 }
 
 // BreakpointLocationsRequest sends a 'breakpointLocations' request.
-func (c *DAPClient) BreakpointLocationsRequest(source string, line int) error {
-	request := &dap.BreakpointLocationsRequest{Request: *c.newRequest("breakpointLocations")}
+func (c *DAPClient) BreakpointLocationsRequest(source string, line int) (int, error) {
+	req, seq := c.newRequest("breakpointLocations")
+	request := &dap.BreakpointLocationsRequest{Request: *req}
 	request.Arguments.Source = dap.Source{
 		Path: source,
 	}
 	request.Arguments.Line = line
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // CompletionsRequest sends a 'completions' request.
-func (c *DAPClient) CompletionsRequest(text string, column int, frameID int) error {
-	request := &dap.CompletionsRequest{Request: *c.newRequest("completions")}
+func (c *DAPClient) CompletionsRequest(text string, column int, frameID int) (int, error) {
+	req, seq := c.newRequest("completions")
+	request := &dap.CompletionsRequest{Request: *req}
 	request.Arguments.Text = text
 	request.Arguments.Column = column
 	request.Arguments.FrameId = frameID
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // DisassembleRequest sends a 'disassemble' request.
-func (c *DAPClient) DisassembleRequest(memoryReference string, instructionOffset, instructionCount int) error {
-	request := &dap.DisassembleRequest{Request: *c.newRequest("disassemble")}
+func (c *DAPClient) DisassembleRequest(memoryReference string, instructionOffset, instructionCount int) (int, error) {
+	req, seq := c.newRequest("disassemble")
+	request := &dap.DisassembleRequest{Request: *req}
 	request.Arguments.MemoryReference = memoryReference
 	request.Arguments.InstructionOffset = instructionOffset
 	request.Arguments.InstructionCount = instructionCount
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // SetExceptionBreakpointsRequest sends a 'setExceptionBreakpoints' request.
-func (c *DAPClient) SetExceptionBreakpointsRequest(filters []string) error {
-	request := &dap.SetExceptionBreakpointsRequest{Request: *c.newRequest("setExceptionBreakpoints")}
+func (c *DAPClient) SetExceptionBreakpointsRequest(filters []string) (int, error) {
+	req, seq := c.newRequest("setExceptionBreakpoints")
+	request := &dap.SetExceptionBreakpointsRequest{Request: *req}
 	request.Arguments.Filters = filters
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // DataBreakpointInfoRequest sends a 'dataBreakpointInfo' request.
-func (c *DAPClient) DataBreakpointInfoRequest(variablesRef int, name string) error {
-	request := &dap.DataBreakpointInfoRequest{Request: *c.newRequest("dataBreakpointInfo")}
+func (c *DAPClient) DataBreakpointInfoRequest(variablesRef int, name string) (int, error) {
+	req, seq := c.newRequest("dataBreakpointInfo")
+	request := &dap.DataBreakpointInfoRequest{Request: *req}
 	request.Arguments.VariablesReference = variablesRef
 	request.Arguments.Name = name
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // SetDataBreakpointsRequest sends a 'setDataBreakpoints' request.
-func (c *DAPClient) SetDataBreakpointsRequest(breakpoints []dap.DataBreakpoint) error {
-	request := &dap.SetDataBreakpointsRequest{Request: *c.newRequest("setDataBreakpoints")}
+func (c *DAPClient) SetDataBreakpointsRequest(breakpoints []dap.DataBreakpoint) (int, error) {
+	req, seq := c.newRequest("setDataBreakpoints")
+	request := &dap.SetDataBreakpointsRequest{Request: *req}
 	request.Arguments.Breakpoints = breakpoints
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // SourceRequest sends a 'source' request.
-func (c *DAPClient) SourceRequest(sourceRef int) error {
-	request := &dap.SourceRequest{Request: *c.newRequest("source")}
+func (c *DAPClient) SourceRequest(sourceRef int) (int, error) {
+	req, seq := c.newRequest("source")
+	request := &dap.SourceRequest{Request: *req}
 	request.Arguments.SourceReference = sourceRef
-	return c.send(request)
+	return seq, c.send(request)
 }
 
 // AttachRequest sends an 'attach' request.
-func (c *DAPClient) AttachRequest(mode string, processID int) error {
-	request := &dap.AttachRequest{Request: *c.newRequest("attach")}
+func (c *DAPClient) AttachRequest(mode string, processID int) (int, error) {
+	req, seq := c.newRequest("attach")
+	request := &dap.AttachRequest{Request: *req}
 	request.Arguments = toRawMessage(map[string]any{
 		"request":   "attach",
 		"mode":      mode,
 		"processId": processID,
 	})
-	return c.send(request)
+	return seq, c.send(request)
 }

--- a/dap.go
+++ b/dap.go
@@ -236,12 +236,24 @@ func (c *DAPClient) VariablesRequest(variablesReference int) error {
 }
 
 // EvaluateRequest sends an 'evaluate' request.
+// We build the arguments as raw JSON instead of using dap.EvaluateArguments
+// because go-dap uses omitempty on FrameId, which drops frameId=0 from the
+// wire. GDB's native DAP uses 0-based frame IDs, so omitting frameId=0
+// causes evaluation in global scope where local variables aren't visible.
 func (c *DAPClient) EvaluateRequest(expression string, frameID int, context string) error {
-	request := &dap.EvaluateRequest{Request: *c.newRequest("evaluate")}
-	request.Arguments.Expression = expression
-	request.Arguments.FrameId = frameID
-	request.Arguments.Context = context
-	return c.send(request)
+	req := c.newRequest("evaluate")
+	args := map[string]any{
+		"expression": expression,
+		"frameId":    frameID,
+	}
+	if context != "" {
+		args["context"] = context
+	}
+	msg := struct {
+		dap.Request
+		Arguments map[string]any `json:"arguments"`
+	}{Request: *req, Arguments: args}
+	return dap.WriteProtocolMessage(c.rwc, &msg)
 }
 
 // DisconnectRequest sends a 'disconnect' request.

--- a/dap_test.go
+++ b/dap_test.go
@@ -26,7 +26,7 @@ func TestNewDAPClientFromRWC(t *testing.T) {
 
 	// Send an initialize request through the client
 	go func() {
-		req, _ := client.newRequest("initialize")
+		req := client.newRequest("initialize")
 		_ = client.send(&dap.InitializeRequest{
 			Request: *req,
 		})

--- a/dap_test.go
+++ b/dap_test.go
@@ -26,8 +26,9 @@ func TestNewDAPClientFromRWC(t *testing.T) {
 
 	// Send an initialize request through the client
 	go func() {
+		req, _ := client.newRequest("initialize")
 		_ = client.send(&dap.InitializeRequest{
-			Request: *client.newRequest("initialize"),
+			Request: *req,
 		})
 	}()
 

--- a/docs/superpowers/plans/2026-03-23-native-gdb-dap.md
+++ b/docs/superpowers/plans/2026-03-23-native-gdb-dap.md
@@ -1,0 +1,711 @@
+# Native GDB DAP Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the OpenDebugAD7 (cpptools) GDB backend with GDB's native DAP server (`gdb -i dap`), eliminating the external adapter dependency.
+
+**Architecture:** The `gdbBackend` struct in `backend.go` is rewritten to spawn `gdb -i dap` instead of `OpenDebugAD7`. Launch arg formats change to GDB's native DAP format. All cpptools discovery logic (`findCpptoolsAdapter`, `MCP_DAP_CPPTOOLS_PATH`) is removed. Documentation and Dockerfile are updated to match.
+
+**Tech Stack:** Go, DAP protocol, GDB 14+
+
+**Spec:** `docs/superpowers/specs/2026-03-23-native-gdb-dap-design.md`
+
+---
+
+### Task 1: Rewrite `gdbBackend` struct and methods in `backend.go`
+
+**Files:**
+- Modify: `backend.go:140-234`
+
+- [ ] **Step 1: Update the `gdbBackend` struct**
+
+Replace the struct at `backend.go:142-146`:
+
+```go
+// gdbBackend implements DebuggerBackend for GDB's native DAP server (gdb -i dap).
+// Requires GDB 14+. Communicates over stdio.
+type gdbBackend struct {
+	gdbPath string // path to gdb binary (default: "gdb")
+	stdin   io.WriteCloser
+	stdout  io.ReadCloser
+}
+```
+
+- [ ] **Step 2: Rewrite `Spawn()` method**
+
+Replace `backend.go:148-175` with:
+
+```go
+// Spawn starts GDB in native DAP mode over stdio.
+// Unlike TCP-based backends, there is no listen address; the process
+// communicates via stdin/stdout pipes.
+func (g *gdbBackend) Spawn(port string, stderrWriter io.Writer) (*exec.Cmd, string, error) {
+	gdbPath := g.gdbPath
+	if gdbPath == "" {
+		gdbPath = "gdb"
+	}
+	cmd := exec.Command(gdbPath, "-i", "dap")
+	cmd.Stderr = stderrWriter
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	g.stdin = stdin
+	g.stdout = stdout
+
+	if err := cmd.Start(); err != nil {
+		return nil, "", fmt.Errorf("failed to start gdb: %w (is GDB 14+ installed?)", err)
+	}
+
+	// stdio transport — no listen address
+	return cmd, "", nil
+}
+```
+
+- [ ] **Step 3: Update `AdapterID()` method**
+
+Replace `backend.go:183-185`:
+
+```go
+// AdapterID returns "gdb" for the native GDB DAP server.
+func (g *gdbBackend) AdapterID() string {
+	return "gdb"
+}
+```
+
+- [ ] **Step 4: `TransportMode()` and `StdioPipes()` — no changes needed**
+
+These methods stay the same (stdio transport, same pipe access pattern). Just update the comments:
+
+Replace the `TransportMode` comment at `backend.go:177-180`:
+
+```go
+// TransportMode returns "stdio" because GDB's native DAP server communicates
+// over process stdin/stdout.
+func (g *gdbBackend) TransportMode() string {
+	return "stdio"
+}
+```
+
+Replace the `StdioPipes` comment at `backend.go:188-192`:
+
+```go
+// StdioPipes returns the captured stdout and stdin pipes from Spawn.
+// These are used to create a DAPClient over the stdio transport.
+func (g *gdbBackend) StdioPipes() (stdout io.ReadCloser, stdin io.WriteCloser) {
+	return g.stdout, g.stdin
+}
+```
+
+- [ ] **Step 5: Rewrite `LaunchArgs()` method**
+
+Replace `backend.go:194-214`:
+
+```go
+// LaunchArgs builds the GDB native DAP argument map for a DAP LaunchRequest.
+// GDB does not support "source" mode; programs must be pre-compiled with
+// debug symbols (gcc -g -O0) and launched in "binary" mode.
+func (g *gdbBackend) LaunchArgs(mode, programPath string, stopOnEntry bool, programArgs []string) (map[string]any, error) {
+	if mode == "source" {
+		return nil, fmt.Errorf("GDB does not support 'source' mode. Compile your program with debug symbols (gcc -g -O0) and use 'binary' mode instead")
+	}
+
+	cwd, _ := os.Getwd()
+	args := map[string]any{
+		"program":     programPath,
+		"cwd":         cwd,
+		"stopAtEntry": stopOnEntry,
+	}
+	if len(programArgs) > 0 {
+		args["args"] = programArgs
+	}
+	return args, nil
+}
+```
+
+- [ ] **Step 6: Rewrite `CoreArgs()` method**
+
+Replace `backend.go:216-225`:
+
+```go
+// CoreArgs builds the GDB native DAP argument map for core dump debugging.
+func (g *gdbBackend) CoreArgs(programPath, coreFilePath string) (map[string]any, error) {
+	return map[string]any{
+		"program":  programPath,
+		"coreFile": coreFilePath,
+	}, nil
+}
+```
+
+- [ ] **Step 7: Rewrite `AttachArgs()` method**
+
+Replace `backend.go:227-234`:
+
+```go
+// AttachArgs builds the GDB native DAP argument map for attaching to a process.
+func (g *gdbBackend) AttachArgs(processID int) (map[string]any, error) {
+	return map[string]any{
+		"pid": processID,
+	}, nil
+}
+```
+
+- [ ] **Step 8: Update `DebuggerBackend` interface comment**
+
+Replace the interface comment at `backend.go:12-14`:
+
+```go
+// DebuggerBackend abstracts the debugger-specific logic for spawning a DAP
+// server and building the launch/attach argument maps. Each supported debugger
+// (Delve, GDB via native DAP, etc.) implements this interface.
+```
+
+And update the `Spawn` comment at `backend.go:17-19`:
+
+```go
+	// Spawn starts the DAP server process. The stderrWriter receives the
+	// adapter's stderr output (typically a log file); pass io.Discard to suppress.
+	// For TCP-based backends (Delve), returns the listen address.
+	// For stdio-based backends (GDB native DAP), returns empty string (use process pipes).
+```
+
+- [ ] **Step 9: Run `go build` to verify compilation**
+
+Run: `go build ./...`
+Expected: no errors
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backend.go
+git commit -m "refactor: rewrite gdbBackend for native GDB DAP server (gdb -i dap)
+
+Replace OpenDebugAD7 (cpptools) with GDB's native DAP mode.
+- Spawn runs 'gdb -i dap' instead of OpenDebugAD7
+- Launch args use GDB native DAP format (no MIMode/miDebuggerPath)
+- CoreArgs uses 'coreFile' instead of 'coreDumpPath'
+- AttachArgs uses 'pid' instead of 'processId'"
+```
+
+---
+
+### Task 2: Update `backend_test.go`
+
+**Files:**
+- Modify: `backend_test.go:118-155`
+
+- [ ] **Step 1: Update `TestGDBBackendLaunchArgs`**
+
+Replace `backend_test.go:118-135`:
+
+```go
+func TestGDBBackendLaunchArgs(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+
+	args, err := backend.LaunchArgs("binary", "/path/to/prog", false, []string{"--flag"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if args["program"] != "/path/to/prog" {
+		t.Errorf("expected program=/path/to/prog, got: %v", args["program"])
+	}
+	if args["stopAtEntry"] != false {
+		t.Errorf("expected stopAtEntry=false, got: %v", args["stopAtEntry"])
+	}
+	if _, ok := args["cwd"]; !ok {
+		t.Error("expected cwd to be set")
+	}
+	programArgs, ok := args["args"].([]string)
+	if !ok {
+		t.Fatalf("expected args to be []string, got: %T", args["args"])
+	}
+	if len(programArgs) != 1 || programArgs[0] != "--flag" {
+		t.Errorf("unexpected args: %v", programArgs)
+	}
+	// Verify cpptools-specific keys are NOT present
+	if _, ok := args["MIMode"]; ok {
+		t.Error("unexpected MIMode key (cpptools artifact)")
+	}
+	if _, ok := args["miDebuggerPath"]; ok {
+		t.Error("unexpected miDebuggerPath key (cpptools artifact)")
+	}
+}
+```
+
+- [ ] **Step 2: Update `TestGDBBackendSourceModeError`**
+
+Replace `backend_test.go:137-147`:
+
+```go
+func TestGDBBackendSourceModeError(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+
+	_, err := backend.LaunchArgs("source", "/path/to/prog", false, nil)
+	if err == nil {
+		t.Fatal("expected error for source mode with GDB")
+	}
+	if !strings.Contains(err.Error(), "source") {
+		t.Errorf("expected error message to mention 'source', got: %s", err.Error())
+	}
+}
+```
+
+- [ ] **Step 3: Update `TestGDBBackendTransportMode`**
+
+Replace `backend_test.go:149-154`:
+
+```go
+func TestGDBBackendTransportMode(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+	if backend.TransportMode() != "stdio" {
+		t.Errorf("expected stdio, got: %s", backend.TransportMode())
+	}
+}
+```
+
+- [ ] **Step 4: Add `TestGDBBackendCoreArgs`**
+
+Insert after `TestGDBBackendTransportMode`:
+
+```go
+func TestGDBBackendCoreArgs(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+	args, err := backend.CoreArgs("/path/to/program", "/path/to/core")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args["program"] != "/path/to/program" {
+		t.Errorf("expected program '/path/to/program', got: %v", args["program"])
+	}
+	if args["coreFile"] != "/path/to/core" {
+		t.Errorf("expected coreFile '/path/to/core', got: %v", args["coreFile"])
+	}
+}
+
+func TestGDBBackendAttachArgs(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+	args, err := backend.AttachArgs(12345)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args["pid"] != 12345 {
+		t.Errorf("expected pid 12345, got: %v", args["pid"])
+	}
+}
+
+func TestGDBBackendAdapterID(t *testing.T) {
+	backend := &gdbBackend{gdbPath: "gdb"}
+	if backend.AdapterID() != "gdb" {
+		t.Errorf("expected 'gdb', got: %s", backend.AdapterID())
+	}
+}
+```
+
+- [ ] **Step 5: Add `TestGDBBackendSpawn`**
+
+Insert after the new tests:
+
+```go
+func TestGDBBackendSpawn(t *testing.T) {
+	if _, err := exec.LookPath("gdb"); err != nil {
+		t.Skip("gdb not found in PATH")
+	}
+
+	backend := &gdbBackend{gdbPath: "gdb"}
+	cmd, listenAddr, err := backend.Spawn(":0", io.Discard)
+	if err != nil {
+		t.Fatalf("failed to spawn gdb: %v", err)
+	}
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	if listenAddr != "" {
+		t.Errorf("expected empty listen address for stdio transport, got: %s", listenAddr)
+	}
+	if backend.TransportMode() != "stdio" {
+		t.Errorf("expected stdio transport, got: %s", backend.TransportMode())
+	}
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test -v -run TestGDBBackend`
+Expected: all GDB backend unit tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend_test.go
+git commit -m "test: update gdbBackend tests for native GDB DAP format"
+```
+
+---
+
+### Task 3: Update `tools.go` — params, descriptions, backend selection
+
+**Files:**
+- Modify: `tools.go:42-50` (debug tool description)
+- Modify: `tools.go:101` (stop tool description)
+- Modify: `tools.go:211-212` (DebugParams fields)
+- Modify: `tools.go:744-765` (backend selection in `debug()`)
+- Delete: `tools.go:1213-1244` (`findCpptoolsAdapter()`)
+
+- [ ] **Step 1: Update `debugToolDescription`**
+
+Replace `tools.go:42-50`:
+
+```go
+const debugToolDescription = `Start a complete debugging session. Returns full context at first breakpoint.
+
+Modes: 'source' (compile & debug), 'binary' (debug executable), 'core' (debug core dump), 'attach' (connect to process).
+
+Debugger selection (via 'debugger' parameter):
+- 'delve' (default): For Go programs only. Requires dlv to be installed.
+- 'gdb': For C/C++/Rust and other compiled languages. Requires GDB 14+ with native DAP support (gdb -i dap). GDB does not support 'source' mode; compile your program with debug symbols (gcc -g -O0) and use 'binary' mode.
+
+Choose the debugger based on the language of the program being debugged: use 'delve' for Go, use 'gdb' for C/C++/Rust.`
+```
+
+- [ ] **Step 2: Update `stop` tool description**
+
+Replace `tools.go:101`:
+
+```go
+		Description: "End the debugging session. By default terminates the debuggee. Pass detach=true to detach without killing the process (leaves it running); detach requires adapter support.",
+```
+
+- [ ] **Step 3: Update `DebugParams` struct**
+
+Replace `tools.go:211-212`:
+
+```go
+	Debugger string `json:"debugger,omitempty" mcp:"debugger to use: 'delve' (default) or 'gdb'"`
+	GDBPath  string `json:"gdbPath,omitempty" mcp:"path to gdb binary (default: auto-detected from PATH). Requires GDB 14+."`
+```
+
+- [ ] **Step 4: Update backend selection in `debug()`**
+
+Replace `tools.go:749-766`:
+
+```go
+	switch debugger {
+	case "delve":
+		ds.backend = &delveBackend{}
+	case "gdb":
+		gdbPath := params.Arguments.GDBPath
+		if gdbPath == "" {
+			var err error
+			gdbPath, err = exec.LookPath("gdb")
+			if err != nil {
+				return nil, fmt.Errorf("GDB not found in PATH. Install GDB 14+ or set the gdbPath parameter")
+			}
+		}
+		ds.backend = &gdbBackend{gdbPath: gdbPath}
+	default:
+		return nil, fmt.Errorf("unsupported debugger: %s (must be 'delve' or 'gdb')", debugger)
+	}
+```
+
+- [ ] **Step 5: Delete `findCpptoolsAdapter()` function**
+
+Delete the entire function at `tools.go:1213-1244`. Also remove the `filepath` import if it's no longer used elsewhere.
+
+Check if `filepath` is used elsewhere:
+
+Run: `grep -n 'filepath\.' tools.go | grep -v findCpptoolsAdapter`
+
+If `filepath` is used elsewhere in `tools.go`, keep the import. If not, remove it.
+
+- [ ] **Step 6: Update cpptools comments in `tools.go`**
+
+Replace the comment at `tools.go:839-847`:
+
+```go
+	// After sending the launch/attach request, we must handle two DAP patterns:
+	//
+	// Delve: launch response arrives immediately, then initialized event.
+	//
+	// GDB native DAP: may send an "initialized" event before or after the
+	// launch response.
+	//
+	// We unify both by reading messages until we see the initialized event,
+	// noting whether the launch response has also arrived.
+```
+
+Replace the comment at `tools.go:893-894`:
+
+```go
+	// For adapters that defer the launch response,
+	// read the deferred launch response now.
+```
+
+Replace the comment at `tools.go:926-935`:
+
+```go
+	// If we have breakpoints and not explicitly stopping on entry, wait for the
+	// debuggee to reach a breakpoint. Different adapters behave differently:
+	//
+	// Delve: stops at entry point first (reason="entry"), then requires
+	// ContinueRequest to proceed to the breakpoint.
+	//
+	// GDB native DAP: with stopAtEntry=false, may run directly to breakpoint
+	// without stopping at entry first.
+	//
+	// We handle both by reading the first StoppedEvent. If it's an entry stop,
+	// we send ContinueRequest and wait for the next stop.
+```
+
+- [ ] **Step 7: Update comment in `dap.go`**
+
+Replace `dap.go:82`:
+
+```go
+			// Skip events (e.g. OutputEvent) during initialization and keep reading
+```
+
+- [ ] **Step 8: Run `go build` to verify compilation**
+
+Run: `go build ./...`
+Expected: no errors
+
+- [ ] **Step 9: Run all tests**
+
+Run: `go test -v`
+Expected: all existing tests still pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add tools.go dap.go
+git commit -m "refactor: update tools.go for native GDB DAP backend
+
+- Update debug tool description to reference GDB 14+ native DAP
+- Rename AdapterPath to GDBPath in DebugParams
+- Simplify backend selection (no more cpptools adapter discovery)
+- Remove findCpptoolsAdapter() function
+- Update cpptools-specific comments throughout"
+```
+
+---
+
+### Task 4: Update `tools_test.go` — GDB integration tests
+
+**Files:**
+- Modify: `tools_test.go:234-244` (`requireGDBDeps`)
+- Modify: `tools_test.go:848-995` (GDB integration tests)
+
+- [ ] **Step 1: Simplify `requireGDBDeps`**
+
+Replace `tools_test.go:234-245`:
+
+```go
+// requireGDBDeps skips the test if GDB is not available.
+func requireGDBDeps(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("gdb"); err != nil {
+		t.Skip("gdb not found in PATH")
+	}
+}
+```
+
+- [ ] **Step 2: Update `TestGDBBasic`**
+
+In `TestGDBBasic` (line ~848), replace the adapter path logic and debug call arguments. Remove:
+
+```go
+	adapterPath := "OpenDebugAD7"
+	if p := os.Getenv("MCP_DAP_CPPTOOLS_PATH"); p != "" {
+		adapterPath = p
+	}
+```
+
+And update the debug call arguments from:
+
+```go
+			"debugger":    "gdb",
+			"adapterPath": adapterPath,
+```
+
+To:
+
+```go
+			"debugger": "gdb",
+```
+
+- [ ] **Step 3: Update `TestGDBStep`**
+
+Same pattern as Step 2 — remove `adapterPath` variable and `"adapterPath"` from the debug call arguments in `TestGDBStep` (line ~900).
+
+- [ ] **Step 4: Update `TestGDBEvaluate`**
+
+Same pattern — remove `adapterPath` variable and `"adapterPath"` from the debug call arguments in `TestGDBEvaluate` (line ~958).
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test -v -run TestGDB`
+Expected: tests pass (or skip if gdb not in PATH)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools_test.go
+git commit -m "test: update GDB integration tests for native DAP backend
+
+Remove OpenDebugAD7/cpptools adapter path references.
+Tests now only require gdb in PATH."
+```
+
+---
+
+### Task 5: Update `Dockerfile.debug`
+
+**Files:**
+- Modify: `Dockerfile.debug`
+
+- [ ] **Step 1: Rewrite `Dockerfile.debug`**
+
+Replace the entire file with:
+
+```dockerfile
+# Stage 1: Install Delve
+FROM golang:1.24-bookworm AS delve-builder
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Stage 2: Final image with all debugging tools
+FROM debian:bookworm-slim
+
+# Install GDB (14+ for native DAP support) and dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gdb \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Delve from builder
+COPY --from=delve-builder /go/bin/dlv /usr/local/bin/dlv
+
+# Copy mcp-dap-server binary (provided by GoReleaser)
+COPY mcp-dap-server /usr/local/bin/mcp-dap-server
+
+ENTRYPOINT ["mcp-dap-server"]
+```
+
+Changes:
+- Removed the entire OpenDebugAD7/cpptools VSIX download block
+- Removed `curl` and `unzip` from dependencies (only needed for cpptools download)
+- Removed `MCP_DAP_CPPTOOLS_PATH` environment variable
+- Updated GDB install comment to note "14+ for native DAP support"
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Dockerfile.debug
+git commit -m "chore: simplify Dockerfile.debug by removing cpptools dependency
+
+GDB's native DAP mode (gdb -i dap) replaces the OpenDebugAD7 adapter.
+No more VSIX download, curl, or unzip needed."
+```
+
+---
+
+### Task 6: Update documentation and skills
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `docs/debugging-workflows.md`
+- Modify: `skills/debug-source.md`
+- Modify: `skills/debug-core-dump.md`
+- Modify: `skills/debug-attach.md`
+- Modify: `prompts.go`
+
+- [ ] **Step 1: Update `CLAUDE.md`**
+
+Find and replace all cpptools/OpenDebugAD7 references. Key changes:
+
+Replace in Project Overview section:
+- `"Supports Delve (Go) and GDB (C/C++ via cpptools adapter)."` → `"Supports Delve (Go) and GDB (C/C++ via native DAP)."`
+
+Replace in backend.go description:
+- `"delveBackend": Spawns "dlv dap", uses TCP transport` (keep as-is)
+- `"gdbBackend": Spawns "OpenDebugAD7" (cpptools), uses stdio transport` → `"gdbBackend": Spawns "gdb -i dap", uses stdio transport`
+
+Replace in Multi-Debugger Support section:
+- `"GDB: C/C++ programs, stdio transport, requires OpenDebugAD7 (cpptools adapter)"` → `"GDB: C/C++ programs, stdio transport, requires GDB 14+ (native DAP)"`
+
+Replace in Dependencies section:
+- `"Optional: OpenDebugAD7 (cpptools) for GDB debugging (set MCP_DAP_CPPTOOLS_PATH or install ms-vscode.cpptools)"` → `"Optional: GDB 14+ for C/C++ debugging (native DAP support via gdb -i dap)"`
+
+Replace in Common Gotchas section:
+- Any mention of "cpptools" in the DAP event ordering notes
+
+- [ ] **Step 2: Update `docs/debugging-workflows.md`**
+
+Replace:
+- `"*GDB does not support compiling from source — compile with gcc -g -O0 first."` — keep as-is, this is still true
+- Any references to cpptools adapter availability checks
+
+- [ ] **Step 3: Update `skills/debug-source.md`**
+
+Replace line 46:
+- `"C/C++: check cpptools adapter; compile with -g -O0"` → `"C/C++: check GDB 14+ is installed; compile with -g -O0"`
+
+- [ ] **Step 4: Update `skills/debug-core-dump.md`**
+
+Replace line 43:
+- `"For C/C++: check cpptools adapter is available (MCP_DAP_CPPTOOLS_PATH)"` → `"For C/C++: check GDB 14+ is installed (gdb --version)"`
+
+- [ ] **Step 5: Update `prompts.go`**
+
+Replace line 192-195 area:
+- `"OpenDebugAD7 (cpptools)"` → `"gdb (native DAP)"`
+
+Replace line 367:
+- `"For C/C++: ensure the cpptools adapter is available"` → `"For C/C++: ensure GDB 14+ is installed (gdb -i dap)"`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md docs/debugging-workflows.md skills/ prompts.go
+git commit -m "docs: update all references from cpptools/OpenDebugAD7 to native GDB DAP
+
+Replace cpptools adapter references with GDB 14+ native DAP (gdb -i dap)
+across CLAUDE.md, debugging workflows, skills, and prompts."
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test -v -race`
+Expected: all tests pass (GDB tests skip if gdb not in PATH)
+
+- [ ] **Step 2: Run linter/build**
+
+Run: `go vet ./...`
+Expected: no issues
+
+- [ ] **Step 3: Search for any remaining cpptools/OpenDebugAD7 references**
+
+Run: `grep -ri 'cpptools\|OpenDebugAD7\|MCP_DAP_CPPTOOLS' --include='*.go' --include='*.md' --include='Dockerfile*'`
+Expected: no matches (except possibly in old design docs under `docs/plans/` or `docs/superpowers/`)
+
+- [ ] **Step 4: Verify `filepath` import cleanup in `tools.go`**
+
+If `findCpptoolsAdapter` was the only user of `filepath` in `tools.go`, ensure the import was removed. Run:
+
+Run: `go build ./...`
+Expected: no unused import errors
+
+- [ ] **Step 5: Commit any final fixups if needed**

--- a/docs/superpowers/specs/2026-03-23-native-gdb-dap-design.md
+++ b/docs/superpowers/specs/2026-03-23-native-gdb-dap-design.md
@@ -1,0 +1,127 @@
+# Native GDB DAP Backend Design
+
+## Goal
+
+Replace the OpenDebugAD7 (cpptools) GDB backend with GDB's native DAP server (`gdb -i dap`), available in GDB 14+. This eliminates the external adapter dependency and simplifies setup.
+
+## Background
+
+The current GDB support uses Microsoft's cpptools DAP adapter (OpenDebugAD7) as a bridge between GDB's MI protocol and DAP. This requires:
+- Downloading and installing the cpptools VSIX or having it installed via VS Code
+- Auto-detection logic searching multiple VS Code extension directories
+- The `MCP_DAP_CPPTOOLS_PATH` environment variable as a fallback
+- cpptools-specific launch arg formats (`MIMode`, `miDebuggerPath`, `coreDumpPath`)
+
+GDB 14 (mid-2024) introduced native DAP support via `gdb -i dap`, making the cpptools adapter unnecessary.
+
+## Design
+
+### gdbBackend struct
+
+The struct simplifies — no more `adapterPath`, just a path to the `gdb` binary:
+
+```go
+type gdbBackend struct {
+    gdbPath string           // path to gdb binary (default: "gdb")
+    stdin   io.WriteCloser
+    stdout  io.ReadCloser
+}
+```
+
+Key method changes:
+- `Spawn()`: Runs `gdb -i dap` instead of `OpenDebugAD7`
+- `TransportMode()`: Returns `"stdio"` (unchanged — native GDB DAP also uses stdio)
+- `AdapterID()`: Returns `"gdb"` instead of `"cppdbg"`
+- `StdioPipes()`: Unchanged
+
+### Launch args format
+
+GDB's native DAP uses a simpler format than cpptools.
+
+**LaunchArgs** (binary mode):
+```go
+map[string]any{
+    "program":     programPath,
+    "args":        programArgs,
+    "stopAtEntry": stopOnEntry,
+    "cwd":         cwd,
+}
+```
+
+No more `MIMode` or `miDebuggerPath` — those were cpptools-specific.
+
+**CoreArgs**:
+```go
+map[string]any{
+    "program":  programPath,
+    "coreFile": coreFilePath,
+}
+```
+
+`coreFile` replaces cpptools' `coreDumpPath`.
+
+**AttachArgs**:
+```go
+map[string]any{
+    "pid": processID,
+}
+```
+
+`pid` replaces cpptools' `processId` + `MIMode`/`miDebuggerPath`.
+
+Source mode remains unsupported (error directing user to compile with `gcc -g -O0` and use binary mode).
+
+### Tool description and parameter changes
+
+- `debug` tool description: Replace cpptools/OpenDebugAD7 references with "Requires GDB 14+ with native DAP support"
+- `DebugParams.AdapterPath` renamed to `DebugParams.GDBPath`: "path to gdb binary (default: auto-detected from PATH)"
+- `stop` tool description: Remove cpptools-specific caveats
+- Backend selection in `debug()`: Remove `findCpptoolsAdapter()` call and `MCP_DAP_CPPTOOLS_PATH` lookup. Check `GDBPath`, fall back to `exec.LookPath("gdb")`, error if not found with message requiring GDB 14+.
+- Delete `findCpptoolsAdapter()` function entirely
+
+### Dockerfile
+
+Remove the entire cpptools VSIX download block. GDB is already installed via `apt-get`. Remove `MCP_DAP_CPPTOOLS_PATH` env var.
+
+### Tests
+
+Update `backend_test.go`:
+- Remove `adapterPath: "OpenDebugAD7"` references
+- Update expected launch args (no `MIMode`/`miDebuggerPath`, `coreDumpPath` -> `coreFile`, `processId` -> `pid`)
+- Add `TestGDBBackendSpawn` that skips if `gdb` not in PATH
+
+### Documentation and skills
+
+Update all references across:
+- `CLAUDE.md`
+- `docs/debugging-workflows.md`
+- `skills/*.md`
+- `prompts.go`
+
+Replace cpptools/OpenDebugAD7 mentions with native GDB DAP.
+
+### Comments cleanup
+
+Remove cpptools-specific comments in `dap.go` and `tools.go` (e.g., "Skip events from cpptools", "cpptools may defer launch response"). Verify native GDB DAP initialize/launch event ordering during implementation and adjust handling if needed.
+
+## File changes
+
+| File | Change |
+|------|--------|
+| `backend.go` | Rewrite `gdbBackend` struct and methods for native GDB DAP |
+| `backend_test.go` | Update GDB tests for new arg formats, add spawn test |
+| `tools.go` | Update `DebugParams`, backend selection, descriptions; delete `findCpptoolsAdapter()` |
+| `tools_test.go` | Update any GDB-related test references |
+| `Dockerfile.debug` | Remove cpptools VSIX install, remove `MCP_DAP_CPPTOOLS_PATH` |
+| `CLAUDE.md` | Update GDB backend description |
+| `docs/debugging-workflows.md` | Update GDB references |
+| `skills/*.md` | Update GDB references |
+| `prompts.go` | Update GDB references in prompt text |
+
+## Constraints
+
+- Target GDB 14+ (broadest native DAP compatibility)
+- Clean replacement — no backward compatibility with cpptools
+- Work done in a feature branch with git worktree
+- If `gdb -i dap` fails to start (e.g., GDB < 14), surface a clear error message indicating GDB 14+ is required
+- Verify exact DAP arg keys (`coreFile`, `pid`, `stopAtEntry`) against GDB 14 DAP behavior during implementation

--- a/tools.go
+++ b/tools.go
@@ -930,7 +930,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 	// Delve: stops at entry point first (reason="entry"), then requires
 	// ContinueRequest to proceed to the breakpoint.
 	//
-	// GDB native DAP: with stopAtEntry=false, may run directly to breakpoint
+	// GDB native DAP: with stopAtBeginningOfMainSubprogram=false, may run directly to breakpoint
 	// without stopping at entry first.
 	//
 	// We handle both by reading the first StoppedEvent. If it's an entry stop,

--- a/tools.go
+++ b/tools.go
@@ -242,8 +242,8 @@ type BreakpointToolParams struct {
 }
 
 // readAndValidateResponse reads DAP messages until it receives the response
-// matching requestSeq. Stale responses (different request_seq) and events
-// are skipped. Returns an error if the matched response indicates failure.
+// matching requestSeq. Out-of-order responses (different request_seq) and
+// events are skipped. Returns an error if the matched response indicates failure.
 func readAndValidateResponse(client *DAPClient, requestSeq int, errorPrefix string) error {
 	for {
 		msg, err := client.ReadMessage()
@@ -254,7 +254,7 @@ func readAndValidateResponse(client *DAPClient, requestSeq int, errorPrefix stri
 		case dap.ResponseMessage:
 			r := resp.GetResponse()
 			if r.RequestSeq != requestSeq {
-				log.Printf("readAndValidateResponse: skipping stale response (request_seq=%d, waiting for %d)",
+				log.Printf("readAndValidateResponse: skipping out-of-order response (request_seq=%d, waiting for %d)",
 					r.RequestSeq, requestSeq)
 				continue
 			}
@@ -269,8 +269,8 @@ func readAndValidateResponse(client *DAPClient, requestSeq int, errorPrefix stri
 }
 
 // readTypedResponse reads DAP messages until it receives a response of type T
-// matching requestSeq. Stale responses (different request_seq) and events are
-// skipped. Returns an error if the matched response indicates failure.
+// matching requestSeq. Out-of-order responses (different request_seq) and
+// events are skipped. Returns an error if the matched response indicates failure.
 //
 // go-dap decodes all failed responses as *dap.ErrorResponse regardless of
 // command, so we match by request_seq rather than Go type alone.
@@ -285,7 +285,7 @@ func readTypedResponse[T dap.ResponseMessage](client *DAPClient, requestSeq int)
 		case T:
 			r := resp.GetResponse()
 			if r.RequestSeq != requestSeq {
-				log.Printf("readTypedResponse: skipping stale %T (request_seq=%d, waiting for %d)",
+				log.Printf("readTypedResponse: skipping out-of-order %T (request_seq=%d, waiting for %d)",
 					resp, r.RequestSeq, requestSeq)
 				continue
 			}
@@ -296,7 +296,7 @@ func readTypedResponse[T dap.ResponseMessage](client *DAPClient, requestSeq int)
 		case dap.ResponseMessage:
 			r := resp.GetResponse()
 			if r.RequestSeq != requestSeq {
-				log.Printf("readTypedResponse: skipping stale %T (request_seq=%d, waiting for %d)",
+				log.Printf("readTypedResponse: skipping out-of-order %T (request_seq=%d, waiting for %d)",
 					resp, r.RequestSeq, requestSeq)
 				continue
 			}
@@ -410,7 +410,7 @@ func (ds *debuggerSession) continueExecution(ctx context.Context, _ *mcp.ServerS
 		case dap.ResponseMessage:
 			r := resp.GetResponse()
 			if r.RequestSeq != continueSeq {
-				log.Printf("continueExecution: skipping stale response (request_seq=%d, waiting for %d)", r.RequestSeq, continueSeq)
+				log.Printf("continueExecution: skipping out-of-order response (request_seq=%d, waiting for %d)", r.RequestSeq, continueSeq)
 				continue
 			}
 			if !r.Success {
@@ -509,7 +509,7 @@ func (ds *debuggerSession) evaluateExpression(ctx context.Context, _ *mcp.Server
 					return nil, fmt.Errorf("unable to evaluate expression: %s", r.Message)
 				}
 			}
-			log.Printf("evaluate: skipping stale %T response (request_seq=%d, waiting for %d)",
+			log.Printf("evaluate: skipping out-of-order %T response (request_seq=%d, waiting for %d)",
 				resp, r.RequestSeq, evalSeq)
 			continue
 		case dap.EventMessage:
@@ -913,7 +913,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 	// We unify both by reading messages until we see the initialized event.
 	// The launch response may arrive before or after — if it arrives here,
 	// we consume it. If it arrives later, it will be automatically skipped
-	// as a stale response by subsequent seq-based readers.
+	// as an out-of-order response by subsequent seq-based readers.
 	for {
 		msg, err := ds.client.ReadMessage()
 		if err != nil {
@@ -963,7 +963,7 @@ initialized:
 	}
 
 	// If the launch response was deferred (arrived after the initialized event),
-	// it will be automatically consumed and skipped as a stale response by
+	// it will be automatically consumed and skipped as an out-of-order response by
 	// subsequent readAndValidateResponse/readTypedResponse calls, which match
 	// by request_seq.
 

--- a/tools.go
+++ b/tools.go
@@ -874,7 +874,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		req, _ := ds.client.newRequest("launch")
+		req := ds.client.newRequest("launch")
 		request := &dap.LaunchRequest{Request: *req}
 		request.Arguments = toRawMessage(launchArgs)
 		if err := ds.client.send(request); err != nil {
@@ -885,7 +885,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		req, _ := ds.client.newRequest("launch")
+		req := ds.client.newRequest("launch")
 		request := &dap.LaunchRequest{Request: *req}
 		request.Arguments = toRawMessage(coreArgs)
 		if err := ds.client.send(request); err != nil {
@@ -896,7 +896,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		req, _ := ds.client.newRequest("attach")
+		req := ds.client.newRequest("attach")
 		request := &dap.AttachRequest{Request: *req}
 		request.Arguments = toRawMessage(attachArgs)
 		if err := ds.client.send(request); err != nil {

--- a/tools.go
+++ b/tools.go
@@ -8,12 +8,14 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/google/go-dap"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type debuggerSession struct {
+	mu              sync.Mutex       // serializes DAP requests to prevent concurrent read races
 	cmd             *exec.Cmd
 	client          *DAPClient
 	server          *mcp.Server      // MCP server for dynamic tool registration
@@ -300,6 +302,8 @@ type StopParams struct {
 
 // clearBreakpoints removes breakpoints.
 func (ds *debuggerSession) clearBreakpoints(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[ClearBreakpointsParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -341,6 +345,8 @@ type ContinueParams struct {
 
 // continueExecution continues execution and returns full context when stopped.
 func (ds *debuggerSession) continueExecution(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[ContinueParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -398,6 +404,8 @@ type PauseParams struct {
 
 // pauseExecution pauses execution of a thread.
 func (ds *debuggerSession) pauseExecution(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[PauseParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -422,6 +430,8 @@ type EvaluateParams struct {
 
 // evaluateExpression evaluates an expression in the context of a stack frame.
 func (ds *debuggerSession) evaluateExpression(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[EvaluateParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -484,6 +494,8 @@ type SetVariableParams struct {
 
 // setVariable sets the value of a variable in the debugged program.
 func (ds *debuggerSession) setVariable(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[SetVariableParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -505,6 +517,8 @@ type RestartParams struct {
 
 // restartDebugger restarts the debugging session.
 func (ds *debuggerSession) restartDebugger(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[RestartParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -530,6 +544,8 @@ func (ds *debuggerSession) restartDebugger(ctx context.Context, _ *mcp.ServerSes
 
 // info returns program metadata.
 func (ds *debuggerSession) info(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[InfoParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -615,6 +631,8 @@ type DisassembleParams struct {
 
 // disassembleCode disassembles code at a memory reference.
 func (ds *debuggerSession) disassembleCode(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[DisassembleParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	log.Printf("disassemble: address=%s offset=%d", params.Arguments.Address, params.Arguments.Offset.Int())
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
@@ -650,6 +668,8 @@ func (ds *debuggerSession) disassembleCode(ctx context.Context, _ *mcp.ServerSes
 // If params.Detach is true, a DAP disconnect request is sent with terminateDebuggee=false
 // so the debuggee keeps running after the adapter disconnects.
 func (ds *debuggerSession) stop(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[StopParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	log.Printf("stop")
 	if ds.cmd == nil && ds.client == nil {
 		return &mcp.CallToolResultFor[any]{
@@ -710,6 +730,8 @@ func (ds *debuggerSession) cleanup() {
 // debug starts a complete debugging session.
 // It starts the debugger, loads the program, sets initial breakpoints, and runs to the first breakpoint.
 func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[DebugParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	// Clean up any existing session before starting a new one
 	ds.cleanup()
 
@@ -975,6 +997,8 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 
 // context returns the full debugging context at the current location.
 func (ds *debuggerSession) context(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[ContextParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	threadID := params.Arguments.ThreadID.Int()
 	if threadID == 0 {
 		threadID = ds.defaultThreadID()
@@ -1018,6 +1042,8 @@ func (ds *debuggerSession) getThreadList() string {
 
 // step executes a step command and returns the full context at the new location.
 func (ds *debuggerSession) step(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[StepParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
@@ -1172,6 +1198,8 @@ func (ds *debuggerSession) writeScopesAndVariables(result *strings.Builder, fram
 
 // breakpoint sets a breakpoint at the specified location.
 func (ds *debuggerSession) breakpoint(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[BreakpointToolParams]) (*mcp.CallToolResultFor[any], error) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}

--- a/tools.go
+++ b/tools.go
@@ -136,7 +136,11 @@ Call with {} (no arguments) to use the current thread and top frame. Only three 
 		Name: "evaluate",
 		Description: `Evaluate an expression in the debugged program's context. Returns the result value and type. All parameters except 'expression' are optional.
 
-Examples: {"expression": "len(items)"}, {"expression": "user.Name"}, {"expression": "x + y"}`,
+The default context is 'watch', which evaluates language expressions (C, C++, Go). Use valid language syntax, not debugger commands.
+
+Examples: {"expression": "x + y"}, {"expression": "*ptr"}, {"expression": "$rsp"}, {"expression": "(int)value"}
+
+For GDB commands (e.g. print/x), use context 'repl': {"expression": "print/x var", "context": "repl"}`,
 	}, ds.evaluateExpression)
 
 	// Info tool with dynamic description based on adapter capabilities

--- a/tools.go
+++ b/tools.go
@@ -241,10 +241,10 @@ type BreakpointToolParams struct {
 	Function string  `json:"function,omitempty" mcp:"function name (alternative to file+line)"`
 }
 
-// readAndValidateResponse reads DAP messages, skipping events, until it
-// receives a ResponseMessage. It returns an error if the response indicates
-// failure or if the read itself fails.
-func readAndValidateResponse(client *DAPClient, errorPrefix string) error {
+// readAndValidateResponse reads DAP messages until it receives the response
+// matching requestSeq. Stale responses (different request_seq) and events
+// are skipped. Returns an error if the matched response indicates failure.
+func readAndValidateResponse(client *DAPClient, requestSeq int, errorPrefix string) error {
 	for {
 		msg, err := client.ReadMessage()
 		if err != nil {
@@ -252,8 +252,14 @@ func readAndValidateResponse(client *DAPClient, errorPrefix string) error {
 		}
 		switch resp := msg.(type) {
 		case dap.ResponseMessage:
-			if !resp.GetResponse().Success {
-				return fmt.Errorf("%s: %s", errorPrefix, resp.GetResponse().Message)
+			r := resp.GetResponse()
+			if r.RequestSeq != requestSeq {
+				log.Printf("readAndValidateResponse: skipping stale response (request_seq=%d, waiting for %d)",
+					r.RequestSeq, requestSeq)
+				continue
+			}
+			if !r.Success {
+				return fmt.Errorf("%s: %s", errorPrefix, r.Message)
 			}
 			return nil
 		case dap.EventMessage:
@@ -262,10 +268,13 @@ func readAndValidateResponse(client *DAPClient, errorPrefix string) error {
 	}
 }
 
-// readTypedResponse reads DAP messages, skipping events, until it receives a
-// response of the expected type T. Returns an error if the response indicates
-// failure or if an unexpected response type is received.
-func readTypedResponse[T dap.ResponseMessage](client *DAPClient) (T, error) {
+// readTypedResponse reads DAP messages until it receives a response of type T
+// matching requestSeq. Stale responses (different request_seq) and events are
+// skipped. Returns an error if the matched response indicates failure.
+//
+// go-dap decodes all failed responses as *dap.ErrorResponse regardless of
+// command, so we match by request_seq rather than Go type alone.
+func readTypedResponse[T dap.ResponseMessage](client *DAPClient, requestSeq int) (T, error) {
 	var zero T
 	for {
 		msg, err := client.ReadMessage()
@@ -274,15 +283,28 @@ func readTypedResponse[T dap.ResponseMessage](client *DAPClient) (T, error) {
 		}
 		switch resp := msg.(type) {
 		case T:
-			if !resp.GetResponse().Success {
-				return zero, errors.New(resp.GetResponse().Message)
+			r := resp.GetResponse()
+			if r.RequestSeq != requestSeq {
+				log.Printf("readTypedResponse: skipping stale %T (request_seq=%d, waiting for %d)",
+					resp, r.RequestSeq, requestSeq)
+				continue
+			}
+			if !r.Success {
+				return zero, errors.New(r.Message)
 			}
 			return resp, nil
 		case dap.ResponseMessage:
-			if !resp.GetResponse().Success {
-				return zero, errors.New(resp.GetResponse().Message)
+			r := resp.GetResponse()
+			if r.RequestSeq != requestSeq {
+				log.Printf("readTypedResponse: skipping stale %T (request_seq=%d, waiting for %d)",
+					resp, r.RequestSeq, requestSeq)
+				continue
 			}
-			return zero, fmt.Errorf("expected %T, got %T", zero, msg)
+			// Matched request_seq but different Go type (e.g. *dap.ErrorResponse).
+			if !r.Success {
+				return zero, errors.New(r.Message)
+			}
+			return zero, fmt.Errorf("expected %T, got %T (request_seq=%d)", zero, resp, requestSeq)
 		case dap.EventMessage:
 			continue
 		}
@@ -310,10 +332,11 @@ func (ds *debuggerSession) clearBreakpoints(ctx context.Context, _ *mcp.ServerSe
 
 	if params.Arguments.All {
 		// Clear all function breakpoints
-		if err := ds.client.SetFunctionBreakpointsRequest([]string{}); err != nil {
+		seq, err := ds.client.SetFunctionBreakpointsRequest([]string{})
+		if err != nil {
 			return nil, err
 		}
-		if err := readAndValidateResponse(ds.client, "unable to clear breakpoints"); err != nil {
+		if err := readAndValidateResponse(ds.client, seq, "unable to clear breakpoints"); err != nil {
 			return nil, err
 		}
 		return &mcp.CallToolResultFor[any]{
@@ -323,10 +346,11 @@ func (ds *debuggerSession) clearBreakpoints(ctx context.Context, _ *mcp.ServerSe
 
 	if params.Arguments.File != "" {
 		// Clear breakpoints in specific file by setting empty list
-		if err := ds.client.SetBreakpointsRequest(params.Arguments.File, []int{}); err != nil {
+		seq, err := ds.client.SetBreakpointsRequest(params.Arguments.File, []int{})
+		if err != nil {
 			return nil, err
 		}
-		if err := readAndValidateResponse(ds.client, "unable to clear breakpoints"); err != nil {
+		if err := readAndValidateResponse(ds.client, seq, "unable to clear breakpoints"); err != nil {
 			return nil, err
 		}
 		return &mcp.CallToolResultFor[any]{
@@ -355,11 +379,11 @@ func (ds *debuggerSession) continueExecution(ctx context.Context, _ *mcp.ServerS
 	if params.Arguments.To != nil {
 		to := params.Arguments.To
 		if to.Function != "" {
-			if err := ds.client.SetFunctionBreakpointsRequest([]string{to.Function}); err != nil {
+			if _, err := ds.client.SetFunctionBreakpointsRequest([]string{to.Function}); err != nil {
 				return nil, err
 			}
 		} else if to.File != "" && to.Line > 0 {
-			if err := ds.client.SetBreakpointsRequest(to.File, []int{to.Line}); err != nil {
+			if _, err := ds.client.SetBreakpointsRequest(to.File, []int{to.Line}); err != nil {
 				return nil, err
 			}
 		}
@@ -372,7 +396,8 @@ func (ds *debuggerSession) continueExecution(ctx context.Context, _ *mcp.ServerS
 	if threadID == 0 {
 		threadID = ds.defaultThreadID()
 	}
-	if err := ds.client.ContinueRequest(threadID); err != nil {
+	continueSeq, err := ds.client.ContinueRequest(threadID)
+	if err != nil {
 		return nil, err
 	}
 
@@ -383,8 +408,13 @@ func (ds *debuggerSession) continueExecution(ctx context.Context, _ *mcp.ServerS
 		}
 		switch resp := msg.(type) {
 		case dap.ResponseMessage:
-			if !resp.GetResponse().Success {
-				return nil, fmt.Errorf("continue failed: %s", resp.GetResponse().Message)
+			r := resp.GetResponse()
+			if r.RequestSeq != continueSeq {
+				log.Printf("continueExecution: skipping stale response (request_seq=%d, waiting for %d)", r.RequestSeq, continueSeq)
+				continue
+			}
+			if !r.Success {
+				return nil, fmt.Errorf("continue failed: %s", r.Message)
 			}
 		case *dap.StoppedEvent:
 			ds.stoppedThreadID = resp.Body.ThreadId
@@ -409,10 +439,11 @@ func (ds *debuggerSession) pauseExecution(ctx context.Context, _ *mcp.ServerSess
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
-	if err := ds.client.PauseRequest(params.Arguments.ThreadID.Int()); err != nil {
+	seq, err := ds.client.PauseRequest(params.Arguments.ThreadID.Int())
+	if err != nil {
 		return nil, err
 	}
-	if err := readAndValidateResponse(ds.client, "unable to pause execution"); err != nil {
+	if err := readAndValidateResponse(ds.client, seq, "unable to pause execution"); err != nil {
 		return nil, err
 	}
 
@@ -449,7 +480,8 @@ func (ds *debuggerSession) evaluateExpression(ctx context.Context, _ *mcp.Server
 	}
 	log.Printf("evaluate: expression=%q frameID=%d context=%q", params.Arguments.Expression, frameID, evalContext)
 
-	if err := ds.client.EvaluateRequest(params.Arguments.Expression, frameID, evalContext); err != nil {
+	evalSeq, err := ds.client.EvaluateRequest(params.Arguments.Expression, frameID, evalContext)
+	if err != nil {
 		return nil, err
 	}
 
@@ -471,16 +503,17 @@ func (ds *debuggerSession) evaluateExpression(ctx context.Context, _ *mcp.Server
 				Content: []mcp.Content{&mcp.TextContent{Text: result}},
 			}, nil
 		case dap.ResponseMessage:
-			if !resp.GetResponse().Success {
-				return nil, fmt.Errorf("unable to evaluate expression: %s", resp.GetResponse().Message)
+			r := resp.GetResponse()
+			if r.RequestSeq == evalSeq {
+				if !r.Success {
+					return nil, fmt.Errorf("unable to evaluate expression: %s", r.Message)
+				}
 			}
-			return &mcp.CallToolResultFor[any]{
-				Content: []mcp.Content{&mcp.TextContent{Text: "(no result)"}},
-			}, nil
+			log.Printf("evaluate: skipping stale %T response (request_seq=%d, waiting for %d)",
+				resp, r.RequestSeq, evalSeq)
+			continue
 		case dap.EventMessage:
 			continue
-		default:
-			return nil, fmt.Errorf("unexpected response type: %T", msg)
 		}
 	}
 }
@@ -499,10 +532,11 @@ func (ds *debuggerSession) setVariable(ctx context.Context, _ *mcp.ServerSession
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
-	if err := ds.client.SetVariableRequest(params.Arguments.VariablesReference.Int(), params.Arguments.Name, params.Arguments.Value); err != nil {
+	seq, err := ds.client.SetVariableRequest(params.Arguments.VariablesReference.Int(), params.Arguments.Name, params.Arguments.Value)
+	if err != nil {
 		return nil, err
 	}
-	if err := readAndValidateResponse(ds.client, "unable to set variable"); err != nil {
+	if err := readAndValidateResponse(ds.client, seq, "unable to set variable"); err != nil {
 		return nil, err
 	}
 	return &mcp.CallToolResultFor[any]{
@@ -522,7 +556,7 @@ func (ds *debuggerSession) restartDebugger(ctx context.Context, _ *mcp.ServerSes
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
-	if err := ds.client.RestartRequest(map[string]any{
+	seq, err := ds.client.RestartRequest(map[string]any{
 		"arguments": map[string]any{
 			"request":     "launch",
 			"mode":        "exec",
@@ -530,10 +564,11 @@ func (ds *debuggerSession) restartDebugger(ctx context.Context, _ *mcp.ServerSes
 			"args":        params.Arguments.Args,
 			"rebuild":     false,
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
-	if err := readAndValidateResponse(ds.client, "unable to restart debugger"); err != nil {
+	if err := readAndValidateResponse(ds.client, seq, "unable to restart debugger"); err != nil {
 		return nil, err
 	}
 
@@ -561,10 +596,11 @@ func (ds *debuggerSession) info(ctx context.Context, _ *mcp.ServerSession, param
 
 	switch infoType {
 	case "threads":
-		if err := ds.client.ThreadsRequest(); err != nil {
+		seq, err := ds.client.ThreadsRequest()
+		if err != nil {
 			return nil, err
 		}
-		resp, err := readTypedResponse[*dap.ThreadsResponse](ds.client)
+		resp, err := readTypedResponse[*dap.ThreadsResponse](ds.client, seq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get threads: %w", err)
 		}
@@ -581,10 +617,11 @@ func (ds *debuggerSession) info(ctx context.Context, _ *mcp.ServerSession, param
 		if !ds.capabilities.SupportsLoadedSourcesRequest {
 			return nil, fmt.Errorf("loaded sources not supported by this debug adapter")
 		}
-		if err := ds.client.LoadedSourcesRequest(); err != nil {
+		seq, err := ds.client.LoadedSourcesRequest()
+		if err != nil {
 			return nil, err
 		}
-		resp, err := readTypedResponse[*dap.LoadedSourcesResponse](ds.client)
+		resp, err := readTypedResponse[*dap.LoadedSourcesResponse](ds.client, seq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get loaded sources: %w", err)
 		}
@@ -601,10 +638,11 @@ func (ds *debuggerSession) info(ctx context.Context, _ *mcp.ServerSession, param
 		if !ds.capabilities.SupportsModulesRequest {
 			return nil, fmt.Errorf("modules not supported by this debug adapter")
 		}
-		if err := ds.client.ModulesRequest(); err != nil {
+		seq, err := ds.client.ModulesRequest()
+		if err != nil {
 			return nil, err
 		}
-		resp, err := readTypedResponse[*dap.ModulesResponse](ds.client)
+		resp, err := readTypedResponse[*dap.ModulesResponse](ds.client, seq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get modules: %w", err)
 		}
@@ -641,11 +679,12 @@ func (ds *debuggerSession) disassembleCode(ctx context.Context, _ *mcp.ServerSes
 	if count == 0 {
 		count = 20
 	}
-	if err := ds.client.DisassembleRequest(params.Arguments.Address, params.Arguments.Offset.Int(), count); err != nil {
+	seq, err := ds.client.DisassembleRequest(params.Arguments.Address, params.Arguments.Offset.Int(), count)
+	if err != nil {
 		return nil, err
 	}
 
-	disResp, err := readTypedResponse[*dap.DisassembleResponse](ds.client)
+	disResp, err := readTypedResponse[*dap.DisassembleResponse](ds.client, seq)
 	if err != nil {
 		return nil, fmt.Errorf("unable to disassemble: %w", err)
 	}
@@ -679,10 +718,11 @@ func (ds *debuggerSession) stop(ctx context.Context, _ *mcp.ServerSession, param
 
 	if params.Arguments.Detach && ds.client != nil {
 		// Send disconnect with terminateDebuggee=false so the debuggee keeps running.
-		if err := ds.client.DisconnectRequest(false); err != nil {
+		seq, err := ds.client.DisconnectRequest(false)
+		if err != nil {
 			log.Printf("stop: disconnect request failed: %v", err)
 		} else {
-			if err := readAndValidateResponse(ds.client, "disconnect"); err != nil {
+			if err := readAndValidateResponse(ds.client, seq, "disconnect"); err != nil {
 				log.Printf("stop: disconnect response error: %v", err)
 			}
 		}
@@ -834,7 +874,8 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		request := &dap.LaunchRequest{Request: *ds.client.newRequest("launch")}
+		req, _ := ds.client.newRequest("launch")
+		request := &dap.LaunchRequest{Request: *req}
 		request.Arguments = toRawMessage(launchArgs)
 		if err := ds.client.send(request); err != nil {
 			return nil, err
@@ -844,7 +885,8 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		request := &dap.LaunchRequest{Request: *ds.client.newRequest("launch")}
+		req, _ := ds.client.newRequest("launch")
+		request := &dap.LaunchRequest{Request: *req}
 		request.Arguments = toRawMessage(coreArgs)
 		if err := ds.client.send(request); err != nil {
 			return nil, err
@@ -854,7 +896,8 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		request := &dap.AttachRequest{Request: *ds.client.newRequest("attach")}
+		req, _ := ds.client.newRequest("attach")
+		request := &dap.AttachRequest{Request: *req}
 		request.Arguments = toRawMessage(attachArgs)
 		if err := ds.client.send(request); err != nil {
 			return nil, err
@@ -867,11 +910,11 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 	// GDB native DAP: may send an "initialized" event before or after the
 	// launch response.
 	//
-	// We unify both by reading messages until we see the initialized event,
-	// noting whether the launch response has also arrived.
-	launchResponseReceived := false
-	initializedReceived := false
-	for !initializedReceived {
+	// We unify both by reading messages until we see the initialized event.
+	// The launch response may arrive before or after — if it arrives here,
+	// we consume it. If it arrives later, it will be automatically skipped
+	// as a stale response by subsequent seq-based readers.
+	for {
 		msg, err := ds.client.ReadMessage()
 		if err != nil {
 			return nil, err
@@ -881,46 +924,48 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 			if !resp.GetResponse().Success {
 				return nil, fmt.Errorf("unable to start debug session: %s", resp.GetResponse().Message)
 			}
-			launchResponseReceived = true
+			// Launch response consumed; continue reading for initialized event
 		case *dap.InitializedEvent:
-			initializedReceived = true
+			_ = resp
+			goto initialized
 		}
 	}
+initialized:
 
 	// Set breakpoints
 	for _, bp := range params.Arguments.Breakpoints {
 		if bp.Function != "" {
-			if err := ds.client.SetFunctionBreakpointsRequest([]string{bp.Function}); err != nil {
+			seq, err := ds.client.SetFunctionBreakpointsRequest([]string{bp.Function})
+			if err != nil {
 				return nil, err
 			}
-			if err := readAndValidateResponse(ds.client, "unable to set function breakpoint"); err != nil {
+			if err := readAndValidateResponse(ds.client, seq, "unable to set function breakpoint"); err != nil {
 				return nil, err
 			}
 		} else if bp.File != "" && bp.Line > 0 {
-			if err := ds.client.SetBreakpointsRequest(bp.File, []int{bp.Line}); err != nil {
+			seq, err := ds.client.SetBreakpointsRequest(bp.File, []int{bp.Line})
+			if err != nil {
 				return nil, err
 			}
-			if err := readAndValidateResponse(ds.client, "unable to set breakpoint"); err != nil {
+			if err := readAndValidateResponse(ds.client, seq, "unable to set breakpoint"); err != nil {
 				return nil, err
 			}
 		}
 	}
 
 	// Configuration done
-	if err := ds.client.ConfigurationDoneRequest(); err != nil {
+	configSeq, err := ds.client.ConfigurationDoneRequest()
+	if err != nil {
 		return nil, err
 	}
-	if err := readAndValidateResponse(ds.client, "unable to complete configuration"); err != nil {
+	if err := readAndValidateResponse(ds.client, configSeq, "unable to complete configuration"); err != nil {
 		return nil, err
 	}
 
-	// For adapters that defer the launch response,
-	// read the deferred launch response now.
-	if !launchResponseReceived {
-		if err := readAndValidateResponse(ds.client, "unable to start debug session"); err != nil {
-			return nil, err
-		}
-	}
+	// If the launch response was deferred (arrived after the initialized event),
+	// it will be automatically consumed and skipped as a stale response by
+	// subsequent readAndValidateResponse/readTypedResponse calls, which match
+	// by request_seq.
 
 	// Register session-specific tools based on capabilities
 	ds.registerSessionTools()
@@ -968,7 +1013,7 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 			case *dap.StoppedEvent:
 				if ev.Body.Reason == "entry" {
 					// Stopped at entry — send continue to reach the breakpoint
-					if err := ds.client.ContinueRequest(ev.Body.ThreadId); err != nil {
+					if _, err := ds.client.ContinueRequest(ev.Body.ThreadId); err != nil {
 						return nil, err
 					}
 					continue
@@ -988,8 +1033,9 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		return ds.getFullContext(stoppedThreadID, 0, 20)
 	}
 
-	// Return simple success message when stopped on entry
-	// (at entry point, stack trace may not be available yet)
+	// Return simple success message when stopped on entry.
+	// The StoppedEvent from the adapter (if any) will be consumed by the
+	// next readTypedResponse call, which skips EventMessages.
 	return &mcp.CallToolResultFor[any]{
 		Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Debug session started for %s. Use 'breakpoint' to set breakpoints and 'continue' to run.", params.Arguments.Path)}},
 	}, nil
@@ -1026,10 +1072,11 @@ func (ds *debuggerSession) getThreadList() string {
 	if ds.client == nil {
 		return ""
 	}
-	if err := ds.client.ThreadsRequest(); err != nil {
+	seq, err := ds.client.ThreadsRequest()
+	if err != nil {
 		return ""
 	}
-	resp, err := readTypedResponse[*dap.ThreadsResponse](ds.client)
+	resp, err := readTypedResponse[*dap.ThreadsResponse](ds.client, seq)
 	if err != nil {
 		return ""
 	}
@@ -1056,17 +1103,23 @@ func (ds *debuggerSession) step(ctx context.Context, _ *mcp.ServerSession, param
 	// Execute the appropriate step command
 	switch params.Arguments.Mode {
 	case "over":
-		if err := ds.client.NextRequest(threadID); err != nil {
+		stepSeq, err := ds.client.NextRequest(threadID)
+		if err != nil {
 			return nil, err
 		}
+		_ = stepSeq
 	case "in":
-		if err := ds.client.StepInRequest(threadID); err != nil {
+		stepSeq, err := ds.client.StepInRequest(threadID)
+		if err != nil {
 			return nil, err
 		}
+		_ = stepSeq
 	case "out":
-		if err := ds.client.StepOutRequest(threadID); err != nil {
+		stepSeq, err := ds.client.StepOutRequest(threadID)
+		if err != nil {
 			return nil, err
 		}
+		_ = stepSeq
 	default:
 		return nil, fmt.Errorf("invalid step mode: %s (must be 'over', 'in', or 'out')", params.Arguments.Mode)
 	}
@@ -1102,10 +1155,11 @@ func (ds *debuggerSession) getFullContext(threadID, frameID, maxFrames int) (*mc
 	var result strings.Builder
 
 	// Get stack trace
-	if err := ds.client.StackTraceRequest(threadID, 0, maxFrames); err != nil {
+	stSeq, err := ds.client.StackTraceRequest(threadID, 0, maxFrames)
+	if err != nil {
 		return nil, err
 	}
-	stResp, err := readTypedResponse[*dap.StackTraceResponse](ds.client)
+	stResp, err := readTypedResponse[*dap.StackTraceResponse](ds.client, stSeq)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get stack trace: %w", err)
 	}
@@ -1155,12 +1209,13 @@ func (ds *debuggerSession) getFullContext(threadID, frameID, maxFrames int) (*mc
 // frame and writes them to the result builder. Errors are written inline
 // rather than propagated, since partial context is better than none.
 func (ds *debuggerSession) writeScopesAndVariables(result *strings.Builder, frameID int) {
-	if err := ds.client.ScopesRequest(frameID); err != nil {
+	scopesSeq, err := ds.client.ScopesRequest(frameID)
+	if err != nil {
 		result.WriteString("## Variables\n(unable to retrieve scopes)\n")
 		return
 	}
 
-	scopesResp, err := readTypedResponse[*dap.ScopesResponse](ds.client)
+	scopesResp, err := readTypedResponse[*dap.ScopesResponse](ds.client, scopesSeq)
 	if err != nil {
 		result.WriteString("## Variables\n(unable to retrieve scopes)\n")
 		return
@@ -1177,11 +1232,12 @@ func (ds *debuggerSession) writeScopesAndVariables(result *strings.Builder, fram
 		if scope.VariablesReference <= 0 {
 			continue
 		}
-		if err := ds.client.VariablesRequest(scope.VariablesReference); err != nil {
+		varSeq, err := ds.client.VariablesRequest(scope.VariablesReference)
+		if err != nil {
 			result.WriteString("  (unable to retrieve variables)\n")
 			continue
 		}
-		varResp, err := readTypedResponse[*dap.VariablesResponse](ds.client)
+		varResp, err := readTypedResponse[*dap.VariablesResponse](ds.client, varSeq)
 		if err != nil {
 			result.WriteString("  (unable to retrieve variables)\n")
 			continue
@@ -1205,10 +1261,11 @@ func (ds *debuggerSession) breakpoint(ctx context.Context, _ *mcp.ServerSession,
 	}
 
 	if params.Arguments.Function != "" {
-		if err := ds.client.SetFunctionBreakpointsRequest([]string{params.Arguments.Function}); err != nil {
+		seq, err := ds.client.SetFunctionBreakpointsRequest([]string{params.Arguments.Function})
+		if err != nil {
 			return nil, err
 		}
-		if err := readAndValidateResponse(ds.client, "unable to set function breakpoint"); err != nil {
+		if err := readAndValidateResponse(ds.client, seq, "unable to set function breakpoint"); err != nil {
 			return nil, err
 		}
 		return &mcp.CallToolResultFor[any]{
@@ -1220,11 +1277,12 @@ func (ds *debuggerSession) breakpoint(ctx context.Context, _ *mcp.ServerSession,
 		return nil, fmt.Errorf("either function or file+line is required")
 	}
 
-	if err := ds.client.SetBreakpointsRequest(params.Arguments.File, []int{params.Arguments.Line.Int()}); err != nil {
+	bpSeq, err := ds.client.SetBreakpointsRequest(params.Arguments.File, []int{params.Arguments.Line.Int()})
+	if err != nil {
 		return nil, err
 	}
 
-	resp, err := readTypedResponse[*dap.SetBreakpointsResponse](ds.client)
+	resp, err := readTypedResponse[*dap.SetBreakpointsResponse](ds.client, bpSeq)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set breakpoint: %w", err)
 	}

--- a/tools.go
+++ b/tools.go
@@ -25,7 +25,7 @@ type debuggerSession struct {
 	programArgs     []string         // command line arguments
 	coreFilePath    string           // path to core dump file (core mode only)
 	stoppedThreadID int              // thread ID from last StoppedEvent (for adapters that use non-sequential IDs)
-	lastFrameID     int              // frame ID from last getFullContext (for adapters that use non-zero frame IDs)
+	lastFrameID     int              // frame ID from last getFullContext; -1 means not set (0 is valid for GDB)
 }
 
 // defaultThreadID returns the thread ID to use when none is specified.
@@ -50,7 +50,7 @@ Choose the debugger based on the language of the program being debugged: use 'de
 // registerTools registers the debugger tools with the MCP server.
 // logWriter is used to redirect adapter stderr output; pass io.Discard to suppress.
 func registerTools(server *mcp.Server, logWriter io.Writer) *debuggerSession {
-	ds := &debuggerSession{server: server, logWriter: logWriter}
+	ds := &debuggerSession{server: server, logWriter: logWriter, lastFrameID: -1}
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "debug",
@@ -411,27 +411,29 @@ func (ds *debuggerSession) pauseExecution(ctx context.Context, _ *mcp.ServerSess
 
 // EvaluateParams defines the parameters for evaluating an expression.
 type EvaluateParams struct {
-	Expression string  `json:"expression" mcp:"expression to evaluate"`
-	FrameID    FlexInt `json:"frameId,omitempty" mcp:"stack frame ID for evaluation context (default: current frame)"`
-	Context    string  `json:"context,omitempty" mcp:"context for evaluation: watch, repl, hover (default: repl)"`
+	Expression string   `json:"expression" mcp:"expression to evaluate"`
+	FrameID    *FlexInt `json:"frameId,omitempty" mcp:"stack frame ID for evaluation context (default: current frame)"`
+	Context    string   `json:"context,omitempty" mcp:"context for evaluation: watch, repl, hover (default: watch)"`
 }
 
 // evaluateExpression evaluates an expression in the context of a stack frame.
 func (ds *debuggerSession) evaluateExpression(ctx context.Context, _ *mcp.ServerSession, params *mcp.CallToolParamsFor[EvaluateParams]) (*mcp.CallToolResultFor[any], error) {
-	log.Printf("evaluate: expression=%q frameID=%d", params.Arguments.Expression, params.Arguments.FrameID.Int())
 	if ds.client == nil {
 		return nil, fmt.Errorf("debugger not started")
 	}
 
 	evalContext := params.Arguments.Context
 	if evalContext == "" {
-		evalContext = "repl"
+		evalContext = "watch"
 	}
 
-	frameID := params.Arguments.FrameID.Int()
-	if frameID == 0 && ds.lastFrameID != 0 {
+	var frameID int
+	if params.Arguments.FrameID != nil {
+		frameID = params.Arguments.FrameID.Int()
+	} else if ds.lastFrameID >= 0 {
 		frameID = ds.lastFrameID
 	}
+	log.Printf("evaluate: expression=%q frameID=%d context=%q", params.Arguments.Expression, frameID, evalContext)
 
 	if err := ds.client.EvaluateRequest(params.Arguments.Expression, frameID, evalContext); err != nil {
 		return nil, err
@@ -697,7 +699,7 @@ func (ds *debuggerSession) cleanup() {
 	ds.coreFilePath = ""
 	ds.capabilities = dap.Capabilities{}
 	ds.stoppedThreadID = 0
-	ds.lastFrameID = 0
+	ds.lastFrameID = -1
 	ds.unregisterSessionTools()
 }
 

--- a/tools_test.go
+++ b/tools_test.go
@@ -997,6 +997,90 @@ func TestGDBEvaluate(t *testing.T) {
 	ts.stopDebugger(t)
 }
 
+// TestGDBEvaluateWatchContext verifies that expression evaluation uses "watch"
+// context by default, so that C expressions (pointer dereference, register
+// access, casts) are evaluated correctly by GDB's native DAP server.
+// This is a regression test for the bug where the default "repl" context
+// caused GDB to interpret expressions as GDB commands, producing
+// "Undefined command" errors.
+func TestGDBEvaluateWatchContext(t *testing.T) {
+	requireGDBDeps(t)
+
+	ts := setupMCPServerAndClient(t)
+	defer ts.cleanup()
+
+	binaryPath, cleanupBinary := compileTestCProgram(t, ts.cwd, "helloworld")
+	defer cleanupBinary()
+
+	f := filepath.Join(ts.cwd, "testdata", "c", "helloworld", "main.c")
+	result, err := ts.session.CallTool(ts.ctx, &mcp.CallToolParams{
+		Name: "debug",
+		Arguments: map[string]any{
+			"debugger": "gdb",
+			"mode":     "binary",
+			"path":     binaryPath,
+			"breakpoints": []map[string]any{
+				{"file": f, "line": 12},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("Debug returned error")
+	}
+
+	tests := []struct {
+		name       string
+		expression string
+		wantSubstr string
+	}{
+		{
+			name:       "bare expression (default watch context)",
+			expression: "x + y",
+			wantSubstr: "30",
+		},
+		{
+			name:       "pointer dereference",
+			expression: "*(&x)",
+			wantSubstr: "10",
+		},
+		{
+			name:       "address-of operator",
+			expression: "&x",
+			wantSubstr: "0x",
+		},
+		{
+			name:       "cast expression",
+			expression: "(long)x",
+			wantSubstr: "10",
+		},
+		{
+			name:       "register access",
+			expression: "$rsp",
+			wantSubstr: "0x",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, isErr := ts.callTool(t, "evaluate", map[string]any{
+				"expression": tc.expression,
+			})
+			if isErr {
+				t.Fatalf("evaluate %q returned error: %s", tc.expression, text)
+			}
+			if !strings.Contains(text, tc.wantSubstr) {
+				t.Errorf("evaluate %q: expected result to contain %q, got: %s", tc.expression, tc.wantSubstr, text)
+			}
+			t.Logf("evaluate %q = %s", tc.expression, text)
+		})
+	}
+
+	ts.stopDebugger(t)
+}
+
 // callTool is a test helper that calls an MCP tool and returns the text content.
 // It fatals on transport errors and returns (text, isError) for tool-level results.
 func (ts *testSetup) callTool(t *testing.T, name string, args map[string]any) (string, bool) {

--- a/tools_test.go
+++ b/tools_test.go
@@ -1084,7 +1084,7 @@ func TestGDBEvaluateWatchContext(t *testing.T) {
 // TestGDBFullFlow exercises a realistic multi-step debugging session with GDB:
 // start with breakpoint → context → set another breakpoint → continue → context
 // → step → context → evaluate → info → continue to end.
-// This is a regression test for DAP response ordering issues where stale
+// This is a regression test for DAP response ordering issues where out-of-order
 // responses (e.g. ContinueResponse arriving after StoppedEvent) caused
 // subsequent tools (context, evaluate) to fail with type mismatch errors
 // like "expected *dap.StackTraceResponse, got *dap.ContinueResponse".
@@ -1131,11 +1131,11 @@ func TestGDBFullFlow(t *testing.T) {
 	// Set a new breakpoint at line 12 (printf) and continue to it.
 	// This exercises: breakpoint response → continue → ContinueResponse + StoppedEvent
 	// → getFullContext (stackTrace + scopes + variables).
-	// The stale ContinueResponse can arrive after StoppedEvent, so getFullContext
-	// must skip it when reading the StackTraceResponse.
+	// The ContinueResponse can arrive after StoppedEvent (out of order), so
+	// getFullContext must skip it when reading the StackTraceResponse.
 	ts.setBreakpointAndContinue(t, f, 12)
 
-	// Get context — this is where stale ContinueResponse would cause
+	// Get context — this is where an out-of-order ContinueResponse would cause
 	// "expected *dap.StackTraceResponse, got *dap.ContinueResponse"
 	contextStr2 := ts.getContextContent(t)
 	t.Logf("Context at second breakpoint:\n%s", contextStr2)

--- a/tools_test.go
+++ b/tools_test.go
@@ -1081,6 +1081,113 @@ func TestGDBEvaluateWatchContext(t *testing.T) {
 	ts.stopDebugger(t)
 }
 
+// TestGDBFullFlow exercises a realistic multi-step debugging session with GDB:
+// start with breakpoint → context → set another breakpoint → continue → context
+// → step → context → evaluate → info → continue to end.
+// This is a regression test for DAP response ordering issues where stale
+// responses (e.g. ContinueResponse arriving after StoppedEvent) caused
+// subsequent tools (context, evaluate) to fail with type mismatch errors
+// like "expected *dap.StackTraceResponse, got *dap.ContinueResponse".
+func TestGDBFullFlow(t *testing.T) {
+	requireGDBDeps(t)
+
+	ts := setupMCPServerAndClient(t)
+	defer ts.cleanup()
+
+	binaryPath, cleanupBinary := compileTestCProgram(t, ts.cwd, "helloworld")
+	defer cleanupBinary()
+
+	f := filepath.Join(ts.cwd, "testdata", "c", "helloworld", "main.c")
+
+	// Start GDB debug session with a breakpoint at line 9 (int x = 10).
+	// The debug tool runs to the breakpoint and returns context.
+	result, err := ts.session.CallTool(ts.ctx, &mcp.CallToolParams{
+		Name: "debug",
+		Arguments: map[string]any{
+			"debugger": "gdb",
+			"mode":     "binary",
+			"path":     binaryPath,
+			"breakpoints": []map[string]any{
+				{"file": f, "line": 9},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start GDB debug session: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("GDB debug session returned error")
+	}
+	t.Log("Session started, stopped at initial breakpoint")
+
+	// Get context at initial breakpoint
+	contextStr := ts.getContextContent(t)
+	t.Logf("Context at initial breakpoint:\n%s", contextStr)
+
+	if !strings.Contains(contextStr, "main") {
+		t.Errorf("Expected context to contain 'main', got: %s", contextStr)
+	}
+
+	// Set a new breakpoint at line 12 (printf) and continue to it.
+	// This exercises: breakpoint response → continue → ContinueResponse + StoppedEvent
+	// → getFullContext (stackTrace + scopes + variables).
+	// The stale ContinueResponse can arrive after StoppedEvent, so getFullContext
+	// must skip it when reading the StackTraceResponse.
+	ts.setBreakpointAndContinue(t, f, 12)
+
+	// Get context — this is where stale ContinueResponse would cause
+	// "expected *dap.StackTraceResponse, got *dap.ContinueResponse"
+	contextStr2 := ts.getContextContent(t)
+	t.Logf("Context at second breakpoint:\n%s", contextStr2)
+
+	if !strings.Contains(contextStr2, "sum") {
+		t.Errorf("Expected context to contain variable 'sum', got: %s", contextStr2)
+	}
+
+	// Evaluate expression in watch context (default)
+	evalResult, evalErr := ts.callTool(t, "evaluate", map[string]any{
+		"expression": "x + y",
+	})
+	if evalErr {
+		t.Fatalf("Evaluate returned error: %s", evalResult)
+	}
+	if !strings.Contains(evalResult, "30") {
+		t.Errorf("Expected evaluation of 'x + y' to contain '30', got: %s", evalResult)
+	}
+	t.Logf("Evaluate x + y = %s", evalResult)
+
+	// Evaluate with pointer dereference
+	evalResult2, evalErr2 := ts.callTool(t, "evaluate", map[string]any{
+		"expression": "*(&sum)",
+	})
+	if evalErr2 {
+		t.Fatalf("Evaluate *(&sum) returned error: %s", evalResult2)
+	}
+	if !strings.Contains(evalResult2, "30") {
+		t.Errorf("Expected evaluation of '*(&sum)' to contain '30', got: %s", evalResult2)
+	}
+	t.Logf("Evaluate *(&sum) = %s", evalResult2)
+
+	// Get info threads — exercises another typed response read
+	threadsResult, threadsErr := ts.callTool(t, "info", map[string]any{"type": "threads"})
+	if threadsErr {
+		t.Fatalf("Info threads returned error: %s", threadsResult)
+	}
+	if !strings.Contains(threadsResult, "Thread") {
+		t.Errorf("Expected threads info to contain 'Thread', got: %s", threadsResult)
+	}
+	t.Logf("Threads: %s", threadsResult)
+
+	// Continue to end — program should terminate
+	continueResult, contErr := ts.callTool(t, "continue", map[string]any{})
+	if contErr {
+		t.Fatalf("Continue returned error: %s", continueResult)
+	}
+	t.Logf("Continue to end: %s", continueResult)
+
+	ts.stopDebugger(t)
+}
+
 // callTool is a test helper that calls an MCP tool and returns the text content.
 // It fatals on transport errors and returns (text, isError) for tool-level results.
 func (ts *testSetup) callTool(t *testing.T, name string, args map[string]any) (string, bool) {


### PR DESCRIPTION
Fix an issue around serialization of certain requests where the frameID gets lost due to the go-dap extension thinking the `int` has its zero value and omitting it.

Rely more heavily on request / response sequencing to ensure we are waiting for and receiving the correct response.