### PR TITLE
Add optional two-level DAP protocol logging

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -140,9 +140,10 @@ func (b *delveBackend) AttachArgs(processID int) (map[string]any, error) {
 // gdbBackend implements DebuggerBackend for GDB's native DAP server.
 // Requires GDB 14+. Communicates over stdio.
 type gdbBackend struct {
-	gdbPath string // path to gdb binary (default: "gdb")
-	stdin   io.WriteCloser
-	stdout  io.ReadCloser
+	gdbPath     string // path to gdb binary (default: "gdb")
+	toolLogPath string // path for GDB's native DAP log file
+	stdin       io.WriteCloser
+	stdout      io.ReadCloser
 }
 
 // Spawn starts GDB in native DAP mode over stdio.
@@ -153,7 +154,11 @@ func (g *gdbBackend) Spawn(port string, stderrWriter io.Writer) (*exec.Cmd, stri
 	if gdbPath == "" {
 		gdbPath = "gdb"
 	}
-	cmd := exec.Command(gdbPath, "-i", "dap")
+	args := []string{"-i", "dap"}
+	if g.toolLogPath != "" {
+		args = append([]string{"-iex", "set debug dap-log-file " + g.toolLogPath}, args...)
+	}
+	cmd := exec.Command(gdbPath, args...)
 	cmd.Stderr = stderrWriter
 
 	stdin, err := cmd.StdinPipe()

--- a/dap.go
+++ b/dap.go
@@ -22,8 +22,9 @@ type readWriteCloser struct {
 // sequence number of the sent request, which callers use to match
 // the corresponding response via request_seq.
 type DAPClient struct {
-	rwc    io.ReadWriteCloser
-	reader *bufio.Reader
+	rwc       io.ReadWriteCloser
+	reader    *bufio.Reader
+	logWriter io.Writer
 	// seq tracks the sequence number for each request sent to the server.
 	seq int
 }
@@ -51,6 +52,11 @@ func newDAPClientFromRWC(rwc io.ReadWriteCloser) *DAPClient {
 // Close closes the client connection.
 func (c *DAPClient) Close() {
 	c.rwc.Close()
+}
+
+// SetProtocolLogger sets a writer for logging all DAP messages sent and received.
+func (c *DAPClient) SetProtocolLogger(w io.Writer) {
+	c.logWriter = w
 }
 
 // InitializeRequest sends an 'initialize' request and returns the server's capabilities.
@@ -91,7 +97,16 @@ func (c *DAPClient) InitializeRequest(adapterID string) (dap.Capabilities, error
 }
 
 func (c *DAPClient) ReadMessage() (dap.Message, error) {
-	return dap.ReadProtocolMessage(c.reader)
+	msg, err := dap.ReadProtocolMessage(c.reader)
+	if err != nil {
+		return nil, err
+	}
+	if c.logWriter != nil {
+		if data, merr := json.Marshal(msg); merr == nil {
+			fmt.Fprintf(c.logWriter, "RECV: <<<%s>>>\n", data)
+		}
+	}
+	return msg, nil
 }
 
 // LaunchRequest sends a 'launch' request with the specified args.
@@ -137,6 +152,11 @@ func (c *DAPClient) newRequest(command string) *dap.Request {
 }
 
 func (c *DAPClient) send(request dap.Message) error {
+	if c.logWriter != nil {
+		if data, err := json.Marshal(request); err == nil {
+			fmt.Fprintf(c.logWriter, "SENT: <<<%s>>>\n", data)
+		}
+	}
 	return dap.WriteProtocolMessage(c.rwc, request)
 }
 
@@ -273,6 +293,11 @@ func (c *DAPClient) EvaluateRequest(expression string, frameID int, context stri
 		dap.Request
 		Arguments map[string]any `json:"arguments"`
 	}{Request: *req, Arguments: args}
+	if c.logWriter != nil {
+		if data, err := json.Marshal(&msg); err == nil {
+			fmt.Fprintf(c.logWriter, "SENT: <<<%s>>>\n", data)
+		}
+	}
 	return req.Seq, dap.WriteProtocolMessage(c.rwc, &msg)
 }
 

--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -28,6 +29,7 @@ type debuggerSession struct {
 	coreFilePath    string           // path to core dump file (core mode only)
 	stoppedThreadID int              // thread ID from last StoppedEvent (for adapters that use non-sequential IDs)
 	lastFrameID     int              // frame ID from last getFullContext; -1 means not set (0 is valid for GDB)
+	protocolLogFile *os.File         // protocol log file (closed on cleanup)
 }
 
 // defaultThreadID returns the thread ID to use when none is specified.
@@ -212,8 +214,10 @@ type DebugParams struct {
 	Breakpoints  []BreakpointSpec `json:"breakpoints,omitempty" mcp:"initial breakpoints"`
 	StopOnEntry  bool             `json:"stopOnEntry,omitempty" mcp:"stop at program entry instead of running to first breakpoint"`
 	Port         string           `json:"port,omitempty" mcp:"port for DAP server (default: auto-assigned)"`
-	Debugger string `json:"debugger,omitempty" mcp:"debugger to use: 'delve' (default) or 'gdb'"`
-	GDBPath  string `json:"gdbPath,omitempty" mcp:"path to gdb binary (default: auto-detected from PATH). Requires GDB 14+."`
+	Debugger    string `json:"debugger,omitempty" mcp:"debugger to use: 'delve' (default) or 'gdb'"`
+	GDBPath     string `json:"gdbPath,omitempty" mcp:"path to gdb binary (default: auto-detected from PATH). Requires GDB 14+."`
+	ProtocolLog string `json:"protocolLog,omitempty" mcp:"file path for protocol-level DAP message logging (what the MCP server sends/receives)"`
+	ToolLog     string `json:"toolLog,omitempty" mcp:"file path for tool-level DAP logging (native debugger logging, GDB only)"`
 }
 
 // ContextParams defines the parameters for getting debugging context.
@@ -746,6 +750,10 @@ func (ds *debuggerSession) cleanup() {
 		ds.client.Close()
 		ds.client = nil
 	}
+	if ds.protocolLogFile != nil {
+		ds.protocolLogFile.Close()
+		ds.protocolLogFile = nil
+	}
 
 	if ds.cmd != nil && ds.cmd.Process != nil {
 		if err := ds.cmd.Process.Kill(); err != nil {
@@ -824,9 +832,13 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 				return nil, fmt.Errorf("GDB not found in PATH. Install GDB 14+ or set the gdbPath parameter")
 			}
 		}
-		ds.backend = &gdbBackend{gdbPath: gdbPath}
+		ds.backend = &gdbBackend{gdbPath: gdbPath, toolLogPath: params.Arguments.ToolLog}
 	default:
 		return nil, fmt.Errorf("unsupported debugger: %s (must be 'delve' or 'gdb')", debugger)
+	}
+
+	if params.Arguments.ToolLog != "" && debugger == "delve" {
+		log.Printf("warning: tool-level logging is not supported for Delve; Delve DAP logs go to the server log")
 	}
 
 	// Spawn DAP server via backend
@@ -854,6 +866,17 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 	default:
 		return nil, fmt.Errorf("unsupported transport mode: %s", ds.backend.TransportMode())
 	}
+
+	// Protocol-level DAP message logging
+	if params.Arguments.ProtocolLog != "" {
+		f, err := os.Create(params.Arguments.ProtocolLog)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open protocol log file: %w", err)
+		}
+		ds.protocolLogFile = f
+		ds.client.SetProtocolLogger(f)
+	}
+
 	caps, err := ds.client.InitializeRequest(ds.backend.AdapterID())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When diagnosing issues between the MCP server and a DAP debugger, it is valuable to see what each side thinks was sent and received. A single log cannot provide this because the MCP server's view may diverge from the debugger's view due to message corruption, buffering issues, or bugs in either side. Two levels of logging allow the logs to be diffed to pinpoint exactly where a problem occurs.

Protocol-level logging (protocolLog parameter) records the DAP JSON messages as the MCP server's DAPClient sees them: what it marshaled for sending and what it unmarshaled after reading. This works with all debugger backends.

Tool-level logging (toolLog parameter) enables the debugger's own native DAP logging. For GDB, this passes -iex 'set debug dap-log-file <path>' so GDB records what it actually received and sent. For Delve, a warning is logged since its DAP output already goes to the server log via stderr.

Both parameters are optional on the debug tool and accept a file path.