### PR TITLE
Gdb core file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,17 @@ claude mcp add mcp-dap-server /path/to/mcp-dap-server
 ### Session Management
 
 #### `debug`
-Start a debugging session. Supports three modes:
+Start a debugging session. Supports four modes:
 - **source**: Compile and debug Go source code
 - **binary**: Debug a pre-compiled executable
+- **core**: Debug a core dump file
 - **attach**: Attach to a running process
 
 **Parameters**:
-- `mode` (string, required): One of 'source', 'binary', or 'attach'
-- `path` (string): Path to source file or binary (required for source/binary modes)
+- `mode` (string, required): One of 'source', 'binary', 'core', or 'attach'
+- `path` (string): Path to source file or binary (required for source/binary modes; optional for core mode with GDB, which can auto-detect it)
 - `args` (array): Arguments to pass to the program
+- `coreFilePath` (string): Path to core dump file (required for core mode)
 - `processId` (number): Process ID (required for attach mode)
 - `breakpoints` (array): Breakpoints to set before running (file:line or function name)
 - `stopOnEntry` (boolean): Stop at program entry point

--- a/backend.go
+++ b/backend.go
@@ -31,6 +31,11 @@ type DebuggerBackend interface {
 	// CoreArgs builds the debugger-specific arguments map for core dump debugging.
 	CoreArgs(programPath, coreFilePath string) (map[string]any, error)
 
+	// CoreRequestType returns the DAP request type ("launch" or "attach")
+	// to use for core dump debugging. Different debuggers handle core files
+	// via different DAP requests.
+	CoreRequestType() string
+
 	// AttachArgs builds the debugger-specific arguments map for attaching to a process.
 	AttachArgs(processID int) (map[string]any, error)
 }
@@ -116,6 +121,11 @@ func (b *delveBackend) LaunchArgs(mode, programPath string, stopOnEntry bool, pr
 		args["args"] = programArgs
 	}
 	return args, nil
+}
+
+// CoreRequestType returns "launch" because Delve handles core dumps via the launch request.
+func (b *delveBackend) CoreRequestType() string {
+	return "launch"
 }
 
 // CoreArgs builds the Delve-specific argument map for core dump debugging.
@@ -219,6 +229,11 @@ func (g *gdbBackend) LaunchArgs(mode, programPath string, stopOnEntry bool, prog
 		args["args"] = programArgs
 	}
 	return args, nil
+}
+
+// CoreRequestType returns "attach" because GDB handles core dumps via the attach request.
+func (g *gdbBackend) CoreRequestType() string {
+	return "attach"
 }
 
 // CoreArgs builds the GDB native DAP argument map for core dump debugging.

--- a/backend.go
+++ b/backend.go
@@ -237,11 +237,15 @@ func (g *gdbBackend) CoreRequestType() string {
 }
 
 // CoreArgs builds the GDB native DAP argument map for core dump debugging.
+// programPath is optional — GDB can auto-detect the executable from the core file.
 func (g *gdbBackend) CoreArgs(programPath, coreFilePath string) (map[string]any, error) {
-	return map[string]any{
-		"program":  programPath,
+	args := map[string]any{
 		"coreFile": coreFilePath,
-	}, nil
+	}
+	if programPath != "" {
+		args["program"] = programPath
+	}
+	return args, nil
 }
 
 // AttachArgs builds the GDB native DAP argument map for attaching to a process.

--- a/docs/debugging-workflows.md
+++ b/docs/debugging-workflows.md
@@ -102,7 +102,7 @@ flowchart TD
 **Key tools:** `debug`, `context`, `evaluate`, `info`, `stop`
 
 **Typical sequence:**
-1. `debug(mode="core", path="/path/to/binary", coreFilePath="/path/to/core")`
+1. `debug(mode="core", path="/path/to/binary", coreFilePath="/path/to/core")` (path is optional for GDB)
 2. `context()` — crash frame and signal
 3. `evaluate(expression="suspiciousVar")` — inspect values
 4. `context(frameId=1)`, `context(frameId=2)` — walk the stack

--- a/skills/debug-core-dump.md
+++ b/skills/debug-core-dump.md
@@ -11,7 +11,7 @@ description: |
 ## Pre-flight checklist
 
 Before starting, confirm:
-1. **Absolute path** to the binary that crashed (must be the exact same build)
+1. **Absolute path** to the binary that crashed (required for Delve; optional for GDB, which can auto-detect it from the core file)
 2. **Absolute path** to the core dump file (usually `core`, `core.<PID>`, or `core.XXXX`)
 3. **Language** (Go → Delve; C/C++ → GDB)
 4. **Do the binary and core match?** A rebuilt binary won't match the core dump.
@@ -29,9 +29,14 @@ Before starting, confirm:
 debug(mode="core", path="/abs/path/to/binary", coreFilePath="/abs/path/to/core", debugger="delve")
 ```
 
-**C/C++:**
+**C/C++ (with explicit binary):**
 ```json
 debug(mode="core", path="/abs/path/to/binary", coreFilePath="/abs/path/to/core", debugger="gdb")
+```
+
+**C/C++ (auto-detect binary from core file):**
+```json
+debug(mode="core", coreFilePath="/abs/path/to/core", debugger="gdb")
 ```
 
 Expected: The debugger loads the core and positions at the crash frame. You see the crash location, stack trace, and local variables.

--- a/testdata/c/coredump/main.c
+++ b/testdata/c/coredump/main.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+
+void crash(int x, const char *msg) {
+    (void)x;
+    (void)msg;
+    abort();
+}
+
+int main() {
+    crash(42, "core dump test");
+    return 0;
+}

--- a/tools.go
+++ b/tools.go
@@ -207,7 +207,7 @@ type BreakpointSpec struct {
 // DebugParams defines the parameters for starting a complete debug session.
 type DebugParams struct {
 	Mode         string           `json:"mode" mcp:"'source' (compile & debug), 'binary' (debug executable), 'core' (debug core dump), or 'attach' (connect to process)"`
-	Path         string           `json:"path,omitempty" mcp:"program path (required for source/binary/core modes)"`
+	Path         string           `json:"path,omitempty" mcp:"program path (required for source/binary modes; optional for core mode with GDB, which can auto-detect it)"`
 	Args         []string         `json:"args,omitempty" mcp:"command line arguments for the program"`
 	CoreFilePath string           `json:"coreFilePath,omitempty" mcp:"path to core dump file (required for core mode)"`
 	ProcessID    int              `json:"processId,omitempty" mcp:"process ID (required for attach mode)"`
@@ -806,13 +806,14 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if params.Arguments.ProcessID == 0 {
 			return nil, fmt.Errorf("processId is required for attach mode")
 		}
+	} else if mode == "core" {
+		if params.Arguments.CoreFilePath == "" {
+			return nil, fmt.Errorf("coreFilePath is required for core mode")
+		}
 	} else {
 		if params.Arguments.Path == "" {
 			return nil, fmt.Errorf("path is required for %s mode", mode)
 		}
-	}
-	if mode == "core" && params.Arguments.CoreFilePath == "" {
-		return nil, fmt.Errorf("coreFilePath is required for core mode")
 	}
 
 	// Select debugger backend
@@ -837,8 +838,13 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		return nil, fmt.Errorf("unsupported debugger: %s (must be 'delve' or 'gdb')", debugger)
 	}
 
+
 	if params.Arguments.ToolLog != "" && debugger == "delve" {
 		log.Printf("warning: tool-level logging is not supported for Delve; Delve DAP logs go to the server log")
+	}
+
+	if mode == "core" && params.Arguments.Path == "" && debugger != "gdb" {
+		return nil, fmt.Errorf("path is required for core mode with %s (only GDB can auto-detect the executable from a core file)", debugger)
 	}
 
 	// Spawn DAP server via backend

--- a/tools.go
+++ b/tools.go
@@ -908,9 +908,17 @@ func (ds *debuggerSession) debug(ctx context.Context, _ *mcp.ServerSession, para
 		if err != nil {
 			return nil, err
 		}
-		req := ds.client.newRequest("launch")
-		request := &dap.LaunchRequest{Request: *req}
-		request.Arguments = toRawMessage(coreArgs)
+		rawArgs := toRawMessage(coreArgs)
+		var request dap.Message
+		if ds.backend.CoreRequestType() == "attach" {
+			req := ds.client.newRequest("attach")
+			request = &dap.AttachRequest{Request: *req, Arguments: rawArgs}
+		} else if ds.backend.CoreRequestType() == "launch" {
+			req := ds.client.newRequest("launch")
+			request = &dap.LaunchRequest{Request: *req, Arguments: rawArgs}
+		} else {
+			return nil, fmt.Errorf("unsupported core request type: %s", ds.backend.CoreRequestType())
+		}
 		if err := ds.client.send(request); err != nil {
 			return nil, err
 		}

--- a/tools_test.go
+++ b/tools_test.go
@@ -1081,7 +1081,56 @@ func TestGDBEvaluateWatchContext(t *testing.T) {
 	ts.stopDebugger(t)
 }
 
+// Basic 'core' debugging test for GDB.
+func TestGDBCoreDump(t *testing.T) {
+	requireGDBDeps(t)
+
+	ts := setupMCPServerAndClient(t)
+	defer ts.cleanup()
+
+	binaryPath, cleanupBinary := compileTestCProgram(t, ts.cwd, "coredump")
+	defer cleanupBinary()
+
+	corePath := generateCoreDump(t, binaryPath)
+	defer os.Remove(corePath)
+
+	result, err := ts.session.CallTool(ts.ctx, &mcp.CallToolParams{
+		Name: "debug",
+		Arguments: map[string]any{
+			"debugger":     "gdb",
+			"mode":         "core",
+			"path":         binaryPath,
+			"coreFilePath": corePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start GDB core debug session: %v", err)
+	}
+	if result.IsError {
+		errorMsg := ""
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+				errorMsg = tc.Text
+			}
+		}
+		t.Fatalf("GDB core debug session returned error: %s", errorMsg)
+	}
+
+	contextStr := ts.getContextContent(t)
+	t.Logf("GDB core dump context:\n%s", contextStr)
+
+	if !strings.Contains(contextStr, "crash") {
+		t.Errorf("Expected stack trace to contain 'crash', got:\n%s", contextStr)
+	}
+	if !strings.Contains(contextStr, "main") {
+		t.Errorf("Expected stack trace to contain 'main', got:\n%s", contextStr)
+	}
+
+	ts.stopDebugger(t)
+}
+
 // TestGDBFullFlow exercises a realistic multi-step debugging session with GDB:
+//
 // start with breakpoint → context → set another breakpoint → continue → context
 // → step → context → evaluate → info → continue to end.
 // This is a regression test for DAP response ordering issues where out-of-order

--- a/tools_test.go
+++ b/tools_test.go
@@ -1129,6 +1129,89 @@ func TestGDBCoreDump(t *testing.T) {
 	ts.stopDebugger(t)
 }
 
+// Start a 'core' session for GDB passing a core file but no
+// executable.  GDB should be able to figure out the executable
+// from the core file.
+func TestGDBCoreDumpWithoutPath(t *testing.T) {
+	requireGDBDeps(t)
+
+	ts := setupMCPServerAndClient(t)
+	defer ts.cleanup()
+
+	binaryPath, cleanupBinary := compileTestCProgram(t, ts.cwd, "coredump")
+	defer cleanupBinary()
+
+	corePath := generateCoreDump(t, binaryPath)
+	defer os.Remove(corePath)
+
+	// Do not pass "path" — GDB should auto-detect the executable from the core file.
+	result, err := ts.session.CallTool(ts.ctx, &mcp.CallToolParams{
+		Name: "debug",
+		Arguments: map[string]any{
+			"debugger":     "gdb",
+			"mode":         "core",
+			"coreFilePath": corePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to start GDB core debug session without path: %v", err)
+	}
+	if result.IsError {
+		errorMsg := ""
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+				errorMsg = tc.Text
+			}
+		}
+		t.Fatalf("GDB core debug session without path returned error: %s", errorMsg)
+	}
+
+	contextStr := ts.getContextContent(t)
+	t.Logf("GDB core dump (no path) context:\n%s", contextStr)
+
+	if !strings.Contains(contextStr, "crash") {
+		t.Errorf("Expected stack trace to contain 'crash', got:\n%s", contextStr)
+	}
+	if !strings.Contains(contextStr, "main") {
+		t.Errorf("Expected stack trace to contain 'main', got:\n%s", contextStr)
+	}
+
+	ts.stopDebugger(t)
+}
+
+// Start a session in 'core' mode, but without a coreFilePath
+// argument.  Expect to see an error.
+func TestGDBCoreDumpMissingCoreFile(t *testing.T) {
+	requireGDBDeps(t)
+
+	ts := setupMCPServerAndClient(t)
+	defer ts.cleanup()
+
+	result, err := ts.session.CallTool(ts.ctx, &mcp.CallToolParams{
+		Name: "debug",
+		Arguments: map[string]any{
+			"debugger": "gdb",
+			"mode":     "core",
+		},
+	})
+	if err != nil {
+		t.Logf("Got expected transport error: %v", err)
+	} else if result.IsError {
+		errorMsg := ""
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+				errorMsg = tc.Text
+			}
+		}
+		if !strings.Contains(errorMsg, "coreFilePath is required") {
+			t.Errorf("Expected 'coreFilePath is required' error, got: %s", errorMsg)
+		}
+		t.Logf("Got expected error: %s", errorMsg)
+	} else {
+		t.Error("Expected error when coreFilePath is not specified")
+	}
+}
+
 // TestGDBFullFlow exercises a realistic multi-step debugging session with GDB:
 //
 // start with breakpoint → context → set another breakpoint → continue → context


### PR DESCRIPTION
Two changes to improve core file debugging using GDB.

1. The first fixes actually starting core file debugging, which is currently broken.  However, this makes use of some features that have only just been merged to upstream GDB.  We could possibly avoid this by doing more work in the mcp server itself, e.g. sending raw GDB commands to load the core file.  But I've not done this for now, preferring to use the latest upstream features to make the mcp server simpler.
2. GDB is pretty good these days at finding the executable that matches a core file, especially if the core file has build-ids within it.  The second commit allows a user to skip specifying the executable `path`, instead allowing GDB to auto-detect it.  I don't know if the delve debugger supports this, so for now I've left `path` as required when using delve for core file debug.  I've also updated the docs in this commit, which in a few places meant adding text describing core file debug as it was otherwise missing.